### PR TITLE
fix(registration): handle 401 on update with reregistration

### DIFF
--- a/src/main/java/io/cryostat/agent/HttpException.java
+++ b/src/main/java/io/cryostat/agent/HttpException.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.agent;
+
+import java.net.URI;
+
+public class HttpException extends RuntimeException {
+    HttpException(int statusCode, URI uri) {
+        super(
+                String.format(
+                        "Unexpected non-OK status code %d on API path %s",
+                        statusCode, uri.toString()));
+    }
+}


### PR DESCRIPTION
Fixes #15

To test, I have two possible procedures. The first is the way I accidentally noticed this behaviour. Run the Cryostat `smoketest.sh` and put the laptop to sleep for a while with everything spun up and running. The default discovery ping period is 5 minutes, but the `CRYOSTAT_DISCOVERY_PING_PERIOD` variable can be set to reduce that time for faster testing cycles. Put the host machine to sleep for at least the ping period, then awaken the machine again and check the logs. The Cryostat logs should reflect that it is responding `401` to the agent(s) because their JWTs are expired. Before this PR this will continue repeating. After this PR, the agents should see the first 401 and react by refreshing their registration, so no subsequent 401s should occur.

To simplify that testing procedure, this patch can also be applied to the Cryostat backend:

```diff
diff --git a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
index d2a91465..0b4914c6 100644
--- a/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
+++ b/src/main/java/io/cryostat/net/web/http/api/v2/DiscoveryPostHandler.java
@@ -117,6 +117,9 @@ class DiscoveryPostHandler extends AbstractDiscoveryJwtConsumingHandler<Void> {
 
     @Override
     void handleWithValidJwt(RoutingContext ctx, JWT jwt) throws Exception {
+        if (Math.random() > 0.9) {
+            throw new ApiException(401, "bad luck");
+        }
         try {
             UUID id =
                     this.uuidFromString.apply(
```

This means 10% of the time, the agents' attempt to publish updates will fail with a 401. The `0.9` can be adjusted to make this more likely.
