### PR TITLE
build(pom): pull -core dep from GitHub Packages

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
-    - run: mvn -B -U clean verify
+    - run: mvn -B -U -s $GITHUB_WORKSPACE/settings.xml clean verify
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,12 +26,17 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
-        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-        settings-path: ${{ github.workspace }} # location for the settings.xml file
+    - name: maven-settings
+      uses: s4u/maven-settings-action@v2
+      with:
+        servers: '[{"id": "github", "username": "dummy", "password": "${GITHUB_TOKEN_REF}"}]'
+        githubServer: false
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore
-    - run: mvn -B -U -s $GITHUB_WORKSPACE/settings.xml clean verify
+    - run: mvn -B -U clean verify
+      env:
+        GITHUB_TOKEN_REF: ${{ secrets.GH_PKGS_READ_TOKEN }}
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: save

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,8 @@ jobs:
       with:
         java-version: '11'
         distribution: 'adopt'
+        server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
+        settings-path: ${{ github.workspace }} # location for the settings.xml file
     - uses: skjolber/maven-cache-github-action@v1
       with:
         step: restore

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -29,7 +29,7 @@ jobs:
     - name: maven-settings
       uses: s4u/maven-settings-action@v2
       with:
-        servers: '[{"id": "github", "username": "dummy", "password": "${GITHUB_TOKEN_REF}"}]'
+        servers: '[{"id": "github", "username": "dummy", "password": "${env.GITHUB_TOKEN_REF}"}]'
         githubServer: false
     - uses: skjolber/maven-cache-github-action@v1
       with:

--- a/.github/workflows/maven-publish.yaml
+++ b/.github/workflows/maven-publish.yaml
@@ -29,7 +29,7 @@ jobs:
         settings-path: ${{ github.workspace }} # location for the settings.xml file
 
     - name: Build with Maven
-      run: mvn -B -U package --file pom.xml
+      run: mvn -B -U package -s $GITHUB_WORKSPACE/settings.xml --file pom.xml
 
     - name: Publish to GitHub Packages Apache Maven
       run: mvn deploy -s $GITHUB_WORKSPACE/settings.xml

--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,13 @@
 <name>cryostat</name>
 <url>http://maven.apache.org</url>
 
+<repositories>
+  <repository>
+    <id>github-cryostat-core</id>
+    <url>https://maven.pkg.github.com/cryostatio/cryostat-core</url>
+  </repository>
+</repositories>
+
 <distributionManagement>
   <repository>
     <id>github</id>

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
 
 <repositories>
   <repository>
-    <id>github-cryostat-core</id>
+    <id>github</id>
     <url>https://maven.pkg.github.com/cryostatio/cryostat-core</url>
   </repository>
 </repositories>


### PR DESCRIPTION
Replaces #17
Related to https://github.com/cryostatio/cryostat-core/issues/92
Consume `cryostat-core` from GitHub Packages Maven repository. Released versions of `-core` built by CI can be pulled and use as dependency for builds. This requires a GH pkgs authentication token secret to be configured in the repository secrets. Pull requests from forks will not be passed this token and so CI will fail on them - this means that all PRs in this repo, and any others that consume dependencies in this way, need to be created from upstream branches, not fork branches. See #4 vs #19.