### PR TITLE
fix(registration): do not restart harvester on refresh

### DIFF
--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -107,6 +107,7 @@ public class Agent {
                                         client.harvester().stop();
                                         break;
                                     case REFRESHED:
+                                        break;
                                     default:
                                         log.error("Unknown registration state: {}", evt.state);
                                         break;

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -99,10 +99,17 @@ public class Agent {
             client.registration()
                     .addRegistrationListener(
                             evt -> {
-                                if (evt.state) {
-                                    client.harvester().start();
-                                } else {
-                                    client.harvester().stop();
+                                switch (evt.state) {
+                                    case REGISTERED:
+                                        client.harvester().start();
+                                        break;
+                                    case UNREGISTERED:
+                                        client.harvester().stop();
+                                        break;
+                                    case REFRESHED:
+                                    default:
+                                        log.error("Unknown registration state: {}", evt.state);
+                                        break;
                                 }
                             });
             client.registration().start();

--- a/src/main/java/io/cryostat/agent/Harvester.java
+++ b/src/main/java/io/cryostat/agent/Harvester.java
@@ -84,6 +84,9 @@ class Harvester implements FlightRecorderListener {
     }
 
     public void start() {
+        if (running) {
+            return;
+        }
         if (period <= 0) {
             log.info("Harvester disabled, period {} < 0", period);
             return;

--- a/src/main/java/io/cryostat/agent/Harvester.java
+++ b/src/main/java/io/cryostat/agent/Harvester.java
@@ -102,7 +102,7 @@ class Harvester implements FlightRecorderListener {
         try {
             FlightRecorder.addListener(this);
             this.flightRecorder = FlightRecorder.getFlightRecorder();
-            log.info("JFR Harvester started");
+            log.info("JFR Harvester started using template {} with period {}ms", template, period);
         } catch (SecurityException | IllegalStateException e) {
             log.error("Harvester could not start", e);
             return;


### PR DESCRIPTION
Fixes #28

- fix(registration): do not restart harvester on refresh
- ignore start request if already started
- log template and period on start
- fixup! fix(registration): do not restart harvester on refresh
