### PR TITLE
fix(max-files): encode value as string, not raw int bytes

### DIFF
--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -49,7 +49,6 @@ import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -348,7 +347,7 @@ public class CryostatClient {
     }
 
     private static InputStream asStream(int i) {
-        return new ByteArrayInputStream(ByteBuffer.allocate(4).putInt(i).array());
+        return new ByteArrayInputStream(Integer.toString(i).getBytes(StandardCharsets.UTF_8));
     }
 
     private <T> HttpResponse<T> assertOkStatus(HttpResponse<T> res) {


### PR DESCRIPTION
Fixes #49

Previously the form value for `max-files` was encoded as the actual 32-bit bytes of the `int` field. It should actually be encoded as the bytes for a UTF-8 string that can be parsed into the `int` value. Otherwise, the server fails to process this field and the request is rejected.
