### PR TITLE
fix(http): use Apache HTTP client

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,8 @@
   <com.google.dagger.compiler.version>2.26</com.google.dagger.compiler.version>
   <io.cryostat.core.version>2.18.0</io.cryostat.core.version>
 
+  <org.apache.httpcomponents.httpclient.version>4.5.13</org.apache.httpcomponents.httpclient.version>
+  <org.apache.httpcomponents.httpmime.version>${org.apache.httpcomponents.httpclient.version}</org.apache.httpcomponents.httpmime.version>
   <com.fasterxml.jackson.version>2.14.1</com.fasterxml.jackson.version>
   <javax.annotation.version>1.3.2</javax.annotation.version><!-- used by smallrye -->
   <io.smallrye.config.version>2.11.1</io.smallrye.config.version>
@@ -68,7 +70,7 @@
 <dependencies>
   <dependency>
     <groupId>io.cryostat</groupId>
-    <!-- This is only used for computing our own JVM's JVM ID - that part coud be extracted out of -core -->
+    <!-- This is only used for computing our own JVM's JVM ID - that part could be extracted out of -core -->
     <artifactId>cryostat-core</artifactId>
     <version>${io.cryostat.core.version}</version>
   </dependency>
@@ -76,6 +78,16 @@
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger</artifactId>
     <version>${com.google.dagger.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpclient</artifactId>
+    <version>${org.apache.httpcomponents.httpclient.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.httpcomponents</groupId>
+    <artifactId>httpmime</artifactId>
+    <version>${org.apache.httpcomponents.httpmime.version}</version>
   </dependency>
   <dependency>
     <groupId>com.fasterxml.jackson.core</groupId>

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -149,15 +149,15 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS)
-    public static long provideCryostatAgentWebclientConnectTimeoutMs(SmallRyeConfig config) {
-        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS, long.class);
+    public static int provideCryostatAgentWebclientConnectTimeoutMs(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS, int.class);
     }
 
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS)
-    public static long provideCryostatAgentWebclientResponseTimeoutMs(SmallRyeConfig config) {
-        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS, long.class);
+    public static int provideCryostatAgentWebclientResponseTimeoutMs(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS, int.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -127,16 +127,7 @@ public class CryostatClient {
                             mapper.writeValueAsString(registrationInfo),
                             ContentType.APPLICATION_JSON));
             log.info("{}", req);
-            return supply(
-                            req,
-                            (res) -> {
-                                log.info(
-                                        "{} {} : {}",
-                                        req.getMethod(),
-                                        req.getURI(),
-                                        res.getStatusLine().getStatusCode());
-                                return res;
-                            })
+            return supply(req, (res) -> logResponse(req, res))
                     .thenApply(res -> assertOkStatus(req, res))
                     .thenApply(
                             res -> {
@@ -173,16 +164,7 @@ public class CryostatClient {
                                         + "?token="
                                         + pluginInfo.getToken()));
         log.info("{}", req);
-        return supply(
-                        req,
-                        (res) -> {
-                            log.info(
-                                    "{} {} : {}",
-                                    req.getMethod(),
-                                    req.getURI(),
-                                    res.getStatusLine().getStatusCode());
-                            return res;
-                        })
+        return supply(req, (res) -> logResponse(req, res))
                 .thenApply(res -> assertOkStatus(req, res))
                 .thenApply(res -> null);
     }
@@ -202,16 +184,7 @@ public class CryostatClient {
                             mapper.writeValueAsString(subtree), ContentType.APPLICATION_JSON));
 
             log.info("{}", req);
-            return supply(
-                            req,
-                            (res) -> {
-                                log.info(
-                                        "{} {} : {}",
-                                        req.getMethod(),
-                                        req.getURI(),
-                                        res.getStatusLine().getStatusCode());
-                                return res;
-                            })
+            return supply(req, (res) -> logResponse(req, res))
                     .thenApply(res -> assertOkStatus(req, res))
                     .thenApply(res -> null);
         } catch (JsonProcessingException e) {
@@ -279,6 +252,11 @@ public class CryostatClient {
                     assertOkStatus(req, res);
                     return (Void) null;
                 });
+    }
+
+    private HttpResponse logResponse(HttpRequestBase req, HttpResponse res) {
+        log.info("{} {} : {}", req.getMethod(), req.getURI(), res.getStatusLine().getStatusCode());
+        return res;
     }
 
     private <T> CompletableFuture<T> supply(HttpRequestBase req, Function<HttpResponse, T> fn) {

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -104,14 +104,13 @@ public class CryostatClient {
             URI callback,
             String realm) {
         this.executor = executor;
-        this.http = http;
         this.mapper = mapper;
+        this.http = http;
         this.jvmId = jvmId;
         this.appName = appName;
         this.baseUri = baseUri;
         this.callback = callback;
         this.realm = realm;
-        this.mapper = new ObjectMapper();
 
         log.info("Using Cryostat baseuri {}", baseUri);
     }

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -54,10 +54,13 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
 
+import io.cryostat.agent.model.DiscoveryNode;
+import io.cryostat.agent.model.PluginInfo;
+import io.cryostat.agent.model.RegistrationInfo;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.CountingInputStream;
 import org.apache.http.HttpResponse;
@@ -74,10 +77,6 @@ import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import io.cryostat.agent.model.DiscoveryNode;
-import io.cryostat.agent.model.PluginInfo;
-import io.cryostat.agent.model.RegistrationInfo;
 
 public class CryostatClient {
 

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -39,13 +39,9 @@ package io.cryostat.agent;
 
 import java.io.BufferedInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
-import java.net.http.HttpRequest;
-import java.net.http.HttpResponse;
-import java.net.http.HttpResponse.BodyHandlers;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
@@ -54,33 +50,34 @@ import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
-
-import javax.net.ssl.SSLContext;
-
-import io.cryostat.agent.model.DiscoveryNode;
-import io.cryostat.agent.model.PluginInfo;
-import io.cryostat.agent.model.RegistrationInfo;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.Executor;
+import java.util.function.Function;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.input.CountingInputStream;
-import org.apache.http.client.config.RequestConfig;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.FormBodyPartBuilder;
-import org.apache.http.entity.mime.HttpMultipartMode;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
-import org.apache.http.impl.client.CloseableHttpClient;
-import org.apache.http.impl.client.HttpClients;
-import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import io.cryostat.agent.model.DiscoveryNode;
+import io.cryostat.agent.model.PluginInfo;
+import io.cryostat.agent.model.RegistrationInfo;
 
 public class CryostatClient {
 
@@ -88,32 +85,26 @@ public class CryostatClient {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
-    private final SSLContext sslCtx;
-    private final HttpClient http;
+    private final Executor executor;
     private final ObjectMapper mapper;
+    private final HttpClient http;
 
     private final String appName;
     private final String jvmId;
     private final URI baseUri;
     private final URI callback;
     private final String realm;
-    private final String authorization;
-    private final long responseTimeoutMs;
-    private final long uploadTimeoutMs;
 
     CryostatClient(
-            SSLContext sslCtx,
+            Executor executor,
             HttpClient http,
             ObjectMapper mapper,
             String jvmId,
             String appName,
             URI baseUri,
             URI callback,
-            String realm,
-            String authorization,
-            long responseTimeoutMs,
-            long uploadTimeoutMs) {
-        this.sslCtx = sslCtx;
+            String realm) {
+        this.executor = executor;
         this.http = http;
         this.mapper = mapper;
         this.jvmId = jvmId;
@@ -121,9 +112,7 @@ public class CryostatClient {
         this.baseUri = baseUri;
         this.callback = callback;
         this.realm = realm;
-        this.authorization = authorization;
-        this.responseTimeoutMs = responseTimeoutMs;
-        this.uploadTimeoutMs = uploadTimeoutMs;
+        this.mapper = new ObjectMapper();
 
         log.info("Using Cryostat baseuri {}", baseUri);
     }
@@ -131,109 +120,99 @@ public class CryostatClient {
     public CompletableFuture<PluginInfo> register(PluginInfo pluginInfo) {
         RegistrationInfo registrationInfo =
                 new RegistrationInfo(pluginInfo.getId(), realm, callback, pluginInfo.getToken());
-        HttpRequest req;
         try {
-            req =
-                    HttpRequest.newBuilder(baseUri.resolve(API_PATH))
-                            .POST(
-                                    HttpRequest.BodyPublishers.ofString(
-                                            mapper.writeValueAsString(registrationInfo)))
-                            .setHeader("Authorization", authorization)
-                            .timeout(Duration.ofMillis(responseTimeoutMs))
-                            .build();
-            log.trace("{}", req);
+            HttpPost req = new HttpPost(baseUri.resolve(API_PATH));
+            req.setEntity(
+                    new StringEntity(
+                            mapper.writeValueAsString(registrationInfo),
+                            ContentType.APPLICATION_JSON));
+            log.info("{}", req);
+            return supply(
+                            req,
+                            (res) -> {
+                                log.info(
+                                        "{} {} : {}",
+                                        req.getMethod(),
+                                        req.getURI(),
+                                        res.getStatusLine().getStatusCode());
+                                return res;
+                            })
+                    .thenApply(res -> assertOkStatus(req, res))
+                    .thenApply(
+                            res -> {
+                                try (InputStream is = res.getEntity().getContent()) {
+                                    return mapper.readValue(is, ObjectNode.class);
+                                } catch (IOException e) {
+                                    log.error("Unable to parse response as JSON", e);
+                                    throw new RegistrationException(e);
+                                }
+                            })
+                    .thenApply(
+                            node -> {
+                                try {
+                                    return mapper.readValue(
+                                            node.get("data").get("result").toString(),
+                                            PluginInfo.class);
+                                } catch (IOException e) {
+                                    log.error("Unable to parse response as JSON", e);
+                                    throw new RegistrationException(e);
+                                }
+                            });
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
         }
-        return http.sendAsync(req, BodyHandlers.ofInputStream())
-                .thenApply(
-                        res -> {
-                            log.trace(
-                                    "{} {} : {}",
-                                    res.request().method(),
-                                    res.request().uri(),
-                                    res.statusCode());
-                            return res;
-                        })
-                .thenApply(this::assertOkStatus)
-                .thenApply(
-                        resp -> {
-                            try {
-                                return mapper.readValue(resp.body(), ObjectNode.class);
-                            } catch (IOException e) {
-                                log.error("Unable to parse response as JSON", e);
-                                throw new RegistrationException(e);
-                            }
-                        })
-                .thenApply(
-                        node -> {
-                            try {
-                                return mapper.readValue(
-                                        node.get("data").get("result").toString(),
-                                        PluginInfo.class);
-                            } catch (IOException e) {
-                                log.error("Unable to parse response as JSON", e);
-                                throw new RegistrationException(e);
-                            }
-                        });
     }
 
     public CompletableFuture<Void> deregister(PluginInfo pluginInfo) {
-        HttpRequest req =
-                HttpRequest.newBuilder(
-                                baseUri.resolve(
-                                        API_PATH
-                                                + "/"
-                                                + pluginInfo.getId()
-                                                + "?token="
-                                                + pluginInfo.getToken()))
-                        .DELETE()
-                        .timeout(Duration.ofMillis(responseTimeoutMs))
-                        .build();
-        log.trace("{}", req);
-        return http.sendAsync(req, BodyHandlers.discarding())
-                .thenApply(
-                        res -> {
-                            log.trace(
+        HttpDelete req =
+                new HttpDelete(
+                        baseUri.resolve(
+                                API_PATH
+                                        + "/"
+                                        + pluginInfo.getId()
+                                        + "?token="
+                                        + pluginInfo.getToken()));
+        log.info("{}", req);
+        return supply(
+                        req,
+                        (res) -> {
+                            log.info(
                                     "{} {} : {}",
-                                    res.request().method(),
-                                    res.request().uri(),
-                                    res.statusCode());
+                                    req.getMethod(),
+                                    req.getURI(),
+                                    res.getStatusLine().getStatusCode());
                             return res;
                         })
-                .thenApply(this::assertOkStatus)
+                .thenApply(res -> assertOkStatus(req, res))
                 .thenApply(res -> null);
     }
 
     public CompletableFuture<Void> update(PluginInfo pluginInfo, Set<DiscoveryNode> subtree) {
-        HttpRequest req;
         try {
-            req =
-                    HttpRequest.newBuilder(
-                                    baseUri.resolve(
-                                            API_PATH
-                                                    + "/"
-                                                    + pluginInfo.getId()
-                                                    + "?token="
-                                                    + pluginInfo.getToken()))
-                            .POST(
-                                    HttpRequest.BodyPublishers.ofString(
-                                            mapper.writeValueAsString(subtree)))
-                            .setHeader("Authorization", authorization)
-                            .timeout(Duration.ofMillis(responseTimeoutMs))
-                            .build();
-            log.trace("{}", req);
-            return http.sendAsync(req, BodyHandlers.discarding())
-                    .thenApply(
-                            res -> {
-                                log.trace(
+            HttpPost req =
+                    new HttpPost(
+                            baseUri.resolve(
+                                    API_PATH
+                                            + "/"
+                                            + pluginInfo.getId()
+                                            + "?token="
+                                            + pluginInfo.getToken()));
+            req.setEntity(
+                    new StringEntity(
+                            mapper.writeValueAsString(subtree), ContentType.APPLICATION_JSON));
+
+            log.info("{}", req);
+            return supply(
+                            req,
+                            (res) -> {
+                                log.info(
                                         "{} {} : {}",
-                                        res.request().method(),
-                                        res.request().uri(),
-                                        res.statusCode());
+                                        req.getMethod(),
+                                        req.getURI(),
+                                        res.getStatusLine().getStatusCode());
                                 return res;
                             })
-                    .thenApply(this::assertOkStatus)
+                    .thenApply(res -> assertOkStatus(req, res))
                     .thenApply(res -> null);
         } catch (JsonProcessingException e) {
             return CompletableFuture.failedFuture(e);
@@ -243,79 +222,75 @@ public class CryostatClient {
     public CompletableFuture<Void> upload(
             Harvester.PushType pushType, String template, int maxFiles, Path recording)
             throws IOException {
-        try (CloseableHttpClient ahttp =
-                HttpClients.custom()
-                        .setSSLContext(sslCtx)
-                        .setSSLHostnameVerifier((hostname, session) -> true)
-                        .setDefaultHeaders(Set.of(new BasicHeader("Authorization", authorization)))
-                        .build()) {
-            Instant start = Instant.now();
-            String timestamp =
-                    start.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]", "");
-            String fileName = String.format("%s_%s_%s.jfr", appName, template, timestamp);
-            Map<String, String> labels =
-                    Map.of(
-                            "jvmId",
-                            jvmId,
-                            "template.name",
-                            template,
-                            "template.type",
-                            "TARGET",
-                            "pushType",
-                            pushType.name());
+        Instant start = Instant.now();
+        String timestamp = start.truncatedTo(ChronoUnit.SECONDS).toString().replaceAll("[-:]", "");
+        String fileName = String.format("%s_%s_%s.jfr", appName, template, timestamp);
+        Map<String, String> labels =
+                Map.of(
+                        "jvmId",
+                        jvmId,
+                        "template.name",
+                        template,
+                        "template.type",
+                        "TARGET",
+                        "pushType",
+                        pushType.name());
 
-            HttpPost req = new HttpPost(baseUri.resolve("/api/beta/recordings/" + jvmId));
-            req.setConfig(
-                    RequestConfig.custom()
-                            .setExpectContinueEnabled(true)
-                            .setAuthenticationEnabled(true)
-                            .build());
+        HttpPost req = new HttpPost(baseUri.resolve("/api/beta/recordings/" + jvmId));
 
-            CountingInputStream is = getRecordingInputStream(recording);
-            MultipartEntityBuilder entityBuilder =
-                    MultipartEntityBuilder.create()
-                            .setMode(HttpMultipartMode.RFC6532)
-                            .addPart(
-                                    FormBodyPartBuilder.create(
-                                                    "recording",
-                                                    new InputStreamBody(
-                                                            is,
-                                                            ContentType.APPLICATION_OCTET_STREAM,
-                                                            fileName))
-                                            .build())
-                            .addPart(
-                                    FormBodyPartBuilder.create(
-                                                    "labels",
-                                                    new StringBody(
-                                                            mapper.writeValueAsString(labels),
-                                                            ContentType.APPLICATION_JSON))
-                                            .build())
-                            .addPart(
-                                    FormBodyPartBuilder.create(
-                                                    "maxFiles",
-                                                    new StringBody(
-                                                            Integer.toString(maxFiles),
-                                                            ContentType.TEXT_PLAIN))
-                                            .build());
-            req.setEntity(entityBuilder.build());
-            try (CloseableHttpResponse res = ahttp.execute(req)) {
-                Instant finish = Instant.now();
-                log.info(
-                        "{} {} ({} -> {}): {}/{}",
-                        req.getMethod(),
-                        res.getStatusLine().getStatusCode(),
-                        fileName,
-                        req.getURI(),
-                        FileUtils.byteCountToDisplaySize(is.getByteCount()),
-                        Duration.between(start, finish));
-                assertOkStatus(req, res);
-                return CompletableFuture.completedFuture(null);
-            } finally {
-                req.releaseConnection();
-            }
-        } catch (IOException e) {
-            log.error("Upload failure", e);
-            throw e;
+        CountingInputStream is = getRecordingInputStream(recording);
+        MultipartEntityBuilder entityBuilder =
+                MultipartEntityBuilder.create()
+                        .addPart(
+                                FormBodyPartBuilder.create(
+                                                "recording",
+                                                new InputStreamBody(
+                                                        is,
+                                                        ContentType.APPLICATION_OCTET_STREAM,
+                                                        fileName))
+                                        .build())
+                        .addPart(
+                                FormBodyPartBuilder.create(
+                                                "labels",
+                                                new StringBody(
+                                                        mapper.writeValueAsString(labels),
+                                                        ContentType.APPLICATION_JSON))
+                                        .build())
+                        .addPart(
+                                FormBodyPartBuilder.create(
+                                                "maxFiles",
+                                                new StringBody(
+                                                        Integer.toString(maxFiles),
+                                                        ContentType.TEXT_PLAIN))
+                                        .build());
+        req.setEntity(entityBuilder.build());
+        return supply(
+                req,
+                (res) -> {
+                    Instant finish = Instant.now();
+                    log.info(
+                            "{} {} ({} -> {}): {}/{}",
+                            req.getMethod(),
+                            res.getStatusLine().getStatusCode(),
+                            fileName,
+                            req.getURI(),
+                            FileUtils.byteCountToDisplaySize(is.getByteCount()),
+                            Duration.between(start, finish));
+                    assertOkStatus(req, res);
+                    return (Void) null;
+                });
+    }
+
+    private <T> CompletableFuture<T> supply(HttpRequestBase req, Function<HttpResponse, T> fn) {
+        return CompletableFuture.supplyAsync(() -> fn.apply(executeQuiet(req)), executor)
+                .whenComplete((v, t) -> req.reset());
+    }
+
+    private HttpResponse executeQuiet(HttpUriRequest req) {
+        try {
+            return http.execute(req);
+        } catch (IOException ioe) {
+            throw new CompletionException(ioe);
         }
     }
 
@@ -323,24 +298,7 @@ public class CryostatClient {
         return new CountingInputStream(new BufferedInputStream(Files.newInputStream(filePath)));
     }
 
-    private <T> HttpResponse<T> assertOkStatus(HttpResponse<T> res) {
-        int sc = res.statusCode();
-        boolean isOk = 200 <= sc && sc < 300;
-        if (!isOk) {
-            log.error("Non-OK response ({}) on HTTP API {}", sc, res.request().uri());
-            URI uri = res.request().uri();
-            try {
-                throw new HttpException(
-                        sc,
-                        new URI(uri.getScheme(), uri.getAuthority(), uri.getPath(), null, null));
-            } catch (URISyntaxException use) {
-                throw new IllegalStateException(use);
-            }
-        }
-        return res;
-    }
-
-    private void assertOkStatus(HttpRequestBase req, CloseableHttpResponse res) {
+    private HttpResponse assertOkStatus(HttpRequestBase req, HttpResponse res) {
         int sc = res.getStatusLine().getStatusCode();
         boolean isOk = 200 <= sc && sc < 300;
         if (!isOk) {
@@ -354,5 +312,6 @@ public class CryostatClient {
                 throw new IllegalStateException(use);
             }
         }
+        return res;
     }
 }

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -172,6 +172,7 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static CryostatClient provideCryostatClient(
+            SSLContext sslCtx,
             HttpClient http,
             ObjectMapper objectMapper,
             @Named(JVM_ID) String jvmId,
@@ -181,19 +182,9 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_UPLOAD_TIMEOUT_MS) long responseTimeoutMs,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS)
-                    long uploadTimeoutMs) {
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) long uploadTimeoutMs) {
         return new CryostatClient(
-                http,
-                objectMapper,
-                jvmId,
-                appName,
-                baseUri,
-                callback,
-                realm,
-                authorization,
-                responseTimeoutMs,
-                uploadTimeoutMs);
+                sslCtx, http, objectMapper, jvmId, appName, baseUri, callback, realm, authorization, responseTimeoutMs, uploadTimeoutMs);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -192,7 +192,8 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization) {
-        return new CryostatClient(executor, http, jvmId, appName, baseUri, callback, realm);
+        return new CryostatClient(
+                executor, http, objectMapper, jvmId, appName, baseUri, callback, realm);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -38,13 +38,12 @@
 package io.cryostat.agent;
 
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
 import java.security.cert.X509Certificate;
-import java.time.Duration;
+import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,6 +65,11 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import dagger.Lazy;
 import dagger.Module;
 import dagger.Provides;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.message.BasicHeader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,21 +150,27 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static HttpClient provideHttpClient(
-            ScheduledExecutorService executor,
             SSLContext sslContext,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME)
-                    boolean verifyHostname,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS)
-                    long connectTimeoutMs) {
-        System.getProperties()
-                .setProperty(
-                        "jdk.internal.httpclient.disableHostnameVerification",
-                        Boolean.toString(!verifyHostname));
-        return HttpClient.newBuilder()
-                .executor(executor)
-                .connectTimeout(Duration.ofMillis(connectTimeoutMs))
-                .sslContext(sslContext)
-                .build();
+            @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME) boolean verifyHostname) {
+        HttpClientBuilder builder =
+                HttpClients.custom()
+                        .setDefaultHeaders(Set.of(new BasicHeader("Authorization", authorization)))
+                        .setSSLContext(sslContext)
+                        .setDefaultRequestConfig(
+                                RequestConfig.custom()
+                                        .setAuthenticationEnabled(true)
+                                        .setExpectContinueEnabled(true)
+                                        .setConnectTimeout(5000)
+                                        .setConnectionRequestTimeout(5000)
+                                        .setSocketTimeout(5000)
+                                        .build());
+
+        if (!verifyHostname) {
+            builder = builder.setSSLHostnameVerifier((hostname, session) -> true);
+        }
+
+        return builder.build();
     }
 
     @Provides
@@ -172,7 +182,7 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static CryostatClient provideCryostatClient(
-            SSLContext sslCtx,
+            ScheduledExecutorService executor,
             HttpClient http,
             ObjectMapper objectMapper,
             @Named(JVM_ID) String jvmId,
@@ -180,11 +190,8 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_BASEURI) URI baseUri,
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
-            @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization,
-            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_UPLOAD_TIMEOUT_MS) long responseTimeoutMs,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) long uploadTimeoutMs) {
-        return new CryostatClient(
-                sslCtx, http, objectMapper, jvmId, appName, baseUri, callback, realm, authorization, responseTimeoutMs, uploadTimeoutMs);
+            @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization) {
+        return new CryostatClient(executor, http, jvmId, appName, baseUri, callback, realm);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -152,7 +152,8 @@ public abstract class MainModule {
     public static HttpClient provideHttpClient(
             SSLContext sslContext,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME) boolean verifyHostname) {
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME)
+                    boolean verifyHostname) {
         HttpClientBuilder builder =
                 HttpClients.custom()
                         .setDefaultHeaders(Set.of(new BasicHeader("Authorization", authorization)))

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -153,7 +153,9 @@ public abstract class MainModule {
             SSLContext sslContext,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_SSL_VERIFY_HOSTNAME)
-                    boolean verifyHostname) {
+                    boolean verifyHostname,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS) int connectTimeout,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) int responseTimeout) {
         HttpClientBuilder builder =
                 HttpClients.custom()
                         .setDefaultHeaders(Set.of(new BasicHeader("Authorization", authorization)))
@@ -162,9 +164,8 @@ public abstract class MainModule {
                                 RequestConfig.custom()
                                         .setAuthenticationEnabled(true)
                                         .setExpectContinueEnabled(true)
-                                        .setConnectTimeout(5000)
-                                        .setConnectionRequestTimeout(5000)
-                                        .setSocketTimeout(5000)
+                                        .setConnectTimeout(connectTimeout)
+                                        .setSocketTimeout(responseTimeout)
                                         .build());
 
         if (!verifyHostname) {


### PR DESCRIPTION
Fixes #54

Replaces the JDK HTTP Client with Apache HTTP Client. This is a more robust and easier to use library, and also fixes the above bug.

To test:
1. `mvn install` to get the JAR into local mvn repo
2. `cd quarkus-test ; ./mvnw package && podman build -t quay.io/andrewazores/quarkus-test:latest -f src/main/docker/Dockerfile.jvm . ; podman image prune -f` to build a `quarkus-test` using this updated agent JAR
3. `cd cryostat ; sh smoketest.sh` to run the smoketest setup. `quarkus-test-agent-{0,1,2}` should spin up, each using the new Agent JAR containing this change. `0` should fail to register itself due to a missing environment variable, but the host application should run as usual. `1` should register itself successfully and then periodically push harvested JFR files. `2` should register itself and do nothing further.
4. `^C` on smoketest.sh to tear down. All three `quarkus-test-agent` instances should cleanly exit along with everything else.