### PR TITLE
feat(plugin): require HTTP Basic authentication

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,6 +50,7 @@
   <com.google.dagger.compiler.version>2.45</com.google.dagger.compiler.version>
   <io.cryostat.core.version>2.19.1</io.cryostat.core.version>
 
+  <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
   <org.apache.httpcomponents.httpclient.version>4.5.13</org.apache.httpcomponents.httpclient.version>
   <org.apache.httpcomponents.httpmime.version>${org.apache.httpcomponents.httpclient.version}</org.apache.httpcomponents.httpmime.version>
   <com.fasterxml.jackson.version>2.14.1</com.fasterxml.jackson.version>
@@ -78,6 +79,11 @@
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger</artifactId>
     <version>${com.google.dagger.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>org.apache.commons</groupId>
+    <artifactId>commons-lang3</artifactId>
+    <version>${org.apache.commons.lang3.version}</version>
   </dependency>
   <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,6 @@
   <com.google.dagger.compiler.version>2.45</com.google.dagger.compiler.version>
   <io.cryostat.core.version>2.19.1</io.cryostat.core.version>
 
-  <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
   <org.apache.commons.io.version>2.11.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.httpclient.version>4.5.13</org.apache.httpcomponents.httpclient.version>
   <org.apache.httpcomponents.httpmime.version>${org.apache.httpcomponents.httpclient.version}</org.apache.httpcomponents.httpmime.version>
@@ -80,11 +79,6 @@
     <groupId>com.google.dagger</groupId>
     <artifactId>dagger</artifactId>
     <version>${com.google.dagger.version}</version>
-  </dependency>
-  <dependency>
-    <groupId>org.apache.commons</groupId>
-    <artifactId>commons-lang3</artifactId>
-    <version>${org.apache.commons.lang3.version}</version>
   </dependency>
   <dependency>
     <groupId>commons-io</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
   <io.cryostat.core.version>2.19.1</io.cryostat.core.version>
 
   <org.apache.commons.lang3.version>3.12.0</org.apache.commons.lang3.version>
+  <org.apache.commons.io.version>2.11.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.httpclient.version>4.5.13</org.apache.httpcomponents.httpclient.version>
   <org.apache.httpcomponents.httpmime.version>${org.apache.httpcomponents.httpclient.version}</org.apache.httpcomponents.httpmime.version>
   <com.fasterxml.jackson.version>2.14.1</com.fasterxml.jackson.version>
@@ -84,6 +85,11 @@
     <groupId>org.apache.commons</groupId>
     <artifactId>commons-lang3</artifactId>
     <version>${org.apache.commons.lang3.version}</version>
+  </dependency>
+  <dependency>
+    <groupId>commons-io</groupId>
+    <artifactId>commons-io</artifactId>
+    <version>${org.apache.commons.io.version}</version>
   </dependency>
   <dependency>
     <groupId>org.apache.httpcomponents</groupId>

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -228,7 +228,7 @@ public class Agent {
                 registration
                         .deregister()
                         .orTimeout(exitDeregistrationTimeout, TimeUnit.MILLISECONDS)
-                        .handleAsync(
+                        .handle(
                                 (v, t) -> {
                                     try {
                                         log.info("Shutting down...");
@@ -245,8 +245,7 @@ public class Agent {
                                         }
                                     }
                                     return null;
-                                },
-                                executor);
+                                });
             }
         }
 

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -103,13 +103,15 @@ public class Agent {
                                 break;
                             case REFRESHED:
                                 break;
+                            case PUBLISHED:
+                                break;
                             default:
                                 log.error("Unknown registration state: {}", evt.state);
                                 break;
                         }
                     });
-            registration.start();
             webServer.start();
+            registration.start();
             log.info("Startup complete");
         } catch (Exception e) {
             log.error(Agent.class.getSimpleName() + " startup failure", e);

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -230,6 +230,9 @@ public class Agent {
                         .orTimeout(exitDeregistrationTimeout, TimeUnit.MILLISECONDS)
                         .handle(
                                 (v, t) -> {
+                                    if (t != null) {
+                                        log.warn("Exception during deregistration", t);
+                                    }
                                     try {
                                         log.info("Shutting down...");
                                         safeCall(webServer::stop);

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -78,6 +78,8 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_APP_NAME = "cryostat.agent.app.name";
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
     public static final String CRYOSTAT_AGENT_APP_JMX_PORT = "cryostat.agent.app.jmx.port";
+    public static final String CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX =
+            "cryostat.agent.app.registration.prefer-jmx";
     public static final String CRYOSTAT_AGENT_REGISTRATION_RETRY_MS =
             "cryostat.agent.registration.retry-ms";
     public static final String CRYOSTAT_AGENT_EXIT_SIGNALS = "cryostat.agent.exit.signals";
@@ -205,6 +207,14 @@ public abstract class ConfigModule {
                 .orElse(
                         Integer.valueOf(
                                 System.getProperty("com.sun.management.jmxremote.port", "-1")));
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX)
+    public static boolean provideCryostatAgentRegistrationPreferJmx(SmallRyeConfig config) {
+        return config.getOptionalValue(CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX, boolean.class)
+                .orElse(false);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -79,7 +79,7 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
     public static final String CRYOSTAT_AGENT_APP_JMX_PORT = "cryostat.agent.app.jmx.port";
     public static final String CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX =
-            "cryostat.agent.app.registration.prefer-jmx";
+            "cryostat.agent.registration.prefer-jmx";
     public static final String CRYOSTAT_AGENT_REGISTRATION_RETRY_MS =
             "cryostat.agent.registration.retry-ms";
     public static final String CRYOSTAT_AGENT_EXIT_SIGNALS = "cryostat.agent.exit.signals";

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -38,6 +38,7 @@
 package io.cryostat.agent;
 
 import java.io.BufferedInputStream;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -161,14 +162,15 @@ public class CryostatClient {
                                     FormBodyPartBuilder.create(
                                                     "username",
                                                     new StringBody(
-                                                            Credentials.user,
+                                                            credentials.user(),
                                                             ContentType.TEXT_PLAIN))
                                             .build())
                             .addPart(
                                     FormBodyPartBuilder.create(
                                                     "password",
-                                                    new StringBody(
-                                                            new String(credentials.pass),
+                                                    new InputStreamBody(
+                                                            new ByteArrayInputStream(
+                                                                    credentials.passBytes()),
                                                             ContentType.TEXT_PLAIN))
                                             .build())
                             .addPart(

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -170,7 +170,7 @@ public class CryostatClient {
                                                     "password",
                                                     new InputStreamBody(
                                                             new ByteArrayInputStream(
-                                                                    credentials.passBytes()),
+                                                                    credentials.pass()),
                                                             ContentType.TEXT_PLAIN))
                                             .build())
                             .addPart(

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -128,7 +128,7 @@ public class CryostatClient {
                     new StringEntity(
                             mapper.writeValueAsString(registrationInfo),
                             ContentType.APPLICATION_JSON));
-            log.info("{}", req);
+            log.info("{} {}", req, mapper.writeValueAsString(registrationInfo));
             return supply(req, (res) -> logResponse(req, res))
                     .thenApply(res -> assertOkStatus(req, res))
                     .thenApply(

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -105,16 +105,12 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static WebServer provideWebServer(
+            Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
-            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             Lazy<Registration> registration) {
-        try {
-            return new WebServer(executor, host, port, callback, registration);
-        } catch (NoSuchAlgorithmException nsae) {
-            throw new RuntimeException(nsae);
-        }
+        return new WebServer(cryostat, executor, host, port, registration);
     }
 
     @Provides
@@ -192,14 +188,12 @@ public abstract class MainModule {
             ScheduledExecutorService executor,
             ObjectMapper objectMapper,
             HttpClient http,
-            WebServer webServer,
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_BASEURI) URI baseUri,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization) {
-        return new CryostatClient(
-                executor, objectMapper, http, webServer, jvmId, appName, baseUri, realm);
+        return new CryostatClient(executor, objectMapper, http, jvmId, appName, baseUri, realm);
     }
 
     @Provides
@@ -207,6 +201,7 @@ public abstract class MainModule {
     public static Registration provideRegistration(
             ScheduledExecutorService executor,
             CryostatClient cryostat,
+            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             WebServer webServer,
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
@@ -218,6 +213,7 @@ public abstract class MainModule {
         return new Registration(
                 executor,
                 cryostat,
+                callback,
                 webServer,
                 jvmId,
                 appName,

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -108,8 +108,9 @@ public abstract class MainModule {
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
+            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             Lazy<Registration> registration) {
-        return new WebServer(executor, host, port, registration);
+        return new WebServer(executor, host, port, callback, registration);
     }
 
     @Provides
@@ -185,16 +186,16 @@ public abstract class MainModule {
     @Singleton
     public static CryostatClient provideCryostatClient(
             ScheduledExecutorService executor,
-            HttpClient http,
             ObjectMapper objectMapper,
+            HttpClient http,
+            WebServer webServer,
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_BASEURI) URI baseUri,
-            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_AUTHORIZATION) String authorization) {
         return new CryostatClient(
-                executor, http, objectMapper, jvmId, appName, baseUri, callback, realm);
+                executor, objectMapper, http, webServer, jvmId, appName, baseUri, realm);
     }
 
     @Provides
@@ -202,22 +203,22 @@ public abstract class MainModule {
     public static Registration provideRegistration(
             ScheduledExecutorService executor,
             CryostatClient cryostat,
+            WebServer webServer,
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_HOSTNAME) String hostname,
-            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX) boolean preferJmx,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_JMX_PORT) int jmxPort,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_RETRY_MS) int registrationRetryMs) {
         return new Registration(
                 executor,
                 cryostat,
+                webServer,
                 jvmId,
                 appName,
                 realm,
                 hostname,
-                callback,
                 preferJmx,
                 jmxPort,
                 registrationRetryMs);

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -110,7 +110,11 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             Lazy<Registration> registration) {
-        return new WebServer(executor, host, port, callback, registration);
+        try {
+            return new WebServer(executor, host, port, callback, registration);
+        } catch (NoSuchAlgorithmException nsae) {
+            throw new RuntimeException(nsae);
+        }
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -207,6 +207,7 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_HOSTNAME) String hostname,
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
+            @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX) boolean preferJmx,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_JMX_PORT) int jmxPort,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_RETRY_MS) int registrationRetryMs) {
         return new Registration(
@@ -217,6 +218,7 @@ public abstract class MainModule {
                 realm,
                 hostname,
                 callback,
+                preferJmx,
                 jmxPort,
                 registrationRetryMs);
     }

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -69,6 +69,7 @@ class Registration {
     private final String realm;
     private final String hostname;
     private final URI callback;
+    private final boolean preferJmx;
     private final int jmxPort;
     private final int registrationRetryMs;
 
@@ -83,6 +84,7 @@ class Registration {
             String realm,
             String hostname,
             URI callback,
+            boolean preferJmx,
             int jmxPort,
             int registrationRetryMs) {
         this.executor = executor;
@@ -92,6 +94,7 @@ class Registration {
         this.realm = realm;
         this.hostname = hostname;
         this.callback = callback;
+        this.preferJmx = preferJmx;
         this.jmxPort = jmxPort;
         this.registrationRetryMs = registrationRetryMs;
     }
@@ -192,19 +195,25 @@ class Registration {
                         .startInstant()
                         .orElse(Instant.EPOCH)
                         .getEpochSecond();
-        URI uri;
-        if (jmxPort > 0) {
+        URI uri = callback;
+        if (preferJmx && jmxPort > 0) {
             uri =
                     URI.create(
                             String.format(
                                     "service:jmx:rmi:///jndi/rmi://%s:%d/jmxrmi",
                                     hostname, jmxPort));
-        } else {
-            uri = callback;
         }
         DiscoveryNode.Target target =
                 new DiscoveryNode.Target(
-                        realm, uri, appName, jvmId, pid, hostname, jmxPort, javaMain, startTime);
+                        realm,
+                        uri,
+                        appName,
+                        jvmId,
+                        pid,
+                        hostname,
+                        uri.getPort(),
+                        javaMain,
+                        startTime);
 
         DiscoveryNode selfNode =
                 new DiscoveryNode(appName + "-" + pluginInfo.getId(), NODE_TYPE, target);

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -126,7 +126,9 @@ class Registration {
                                     (id, t) -> {
                                         if (t != null) {
                                             log.error("Failed to submit credentials", t);
+                                            throw new RegistrationException(t);
                                         }
+                                        log.info("Submitted credentials with id {}", id);
                                         this.credentialId = id;
                                         return id;
                                     });

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -134,7 +134,6 @@ class Registration {
         CompletableFuture<Void> f =
                 creds.thenComposeAsync(
                         credentialId -> {
-                            this.credentialId = credentialId;
                             try {
                                 URI credentialedCallback =
                                         new URIBuilder(callback)

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -240,7 +240,7 @@ class Registration {
         DiscoveryNode.Target target =
                 new DiscoveryNode.Target(
                         realm,
-                        callback,
+                        uri,
                         appName,
                         jvmId,
                         pid,

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -267,12 +267,11 @@ class Registration {
                         (n, t) -> {
                             if (t != null) {
                                 log.warn(
-                                        "Failed to deregister as Cryostat"
-                                                + " discovery plugin [{}]",
+                                        "Failed to deregister as Cryostat discovery plugin [{}]",
                                         this.pluginInfo.getId());
                             } else {
                                 log.info(
-                                        "Deregistered from Cryostat" + " discovery plugin [{}]",
+                                        "Deregistered from Cryostat discovery plugin [{}]",
                                         this.pluginInfo.getId());
                             }
                             this.pluginInfo.clear();

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -38,6 +38,7 @@
 package io.cryostat.agent;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.Instant;
@@ -64,11 +65,11 @@ class Registration {
 
     private final ScheduledExecutorService executor;
     private final CryostatClient cryostat;
+    private final WebServer webServer;
     private final String jvmId;
     private final String appName;
     private final String realm;
     private final String hostname;
-    private final URI callback;
     private final boolean preferJmx;
     private final int jmxPort;
     private final int registrationRetryMs;
@@ -79,21 +80,21 @@ class Registration {
     Registration(
             ScheduledExecutorService executor,
             CryostatClient cryostat,
+            WebServer webServer,
             String jvmId,
             String appName,
             String realm,
             String hostname,
-            URI callback,
             boolean preferJmx,
             int jmxPort,
             int registrationRetryMs) {
         this.executor = executor;
         this.cryostat = cryostat;
+        this.webServer = webServer;
         this.jvmId = jvmId;
         this.appName = appName;
         this.realm = realm;
         this.hostname = hostname;
-        this.callback = callback;
         this.preferJmx = preferJmx;
         this.jmxPort = jmxPort;
         this.registrationRetryMs = registrationRetryMs;
@@ -149,8 +150,8 @@ class Registration {
         DiscoveryNode selfNode;
         try {
             selfNode = defineSelf();
-        } catch (UnknownHostException uhe) {
-            log.error("Unable to define self", uhe);
+        } catch (UnknownHostException | URISyntaxException e) {
+            log.error("Unable to define self", e);
             return;
         }
         log.info("publishing self as {}", selfNode.getTarget().getConnectUrl());
@@ -171,6 +172,7 @@ class Registration {
                                                         executor);
                                     } else {
                                         log.info("Publish success");
+                                        notify(RegistrationEvent.State.PUBLISHED);
                                     }
                                     return (Void) null;
                                 },
@@ -182,7 +184,7 @@ class Registration {
         }
     }
 
-    private DiscoveryNode defineSelf() throws UnknownHostException {
+    private DiscoveryNode defineSelf() throws UnknownHostException, URISyntaxException {
         long pid = ProcessHandle.current().pid();
         String javaMain = System.getProperty("sun.java.command", System.getenv("JAVA_MAIN_CLASS"));
         if (StringUtils.isBlank(javaMain)) {
@@ -195,7 +197,7 @@ class Registration {
                         .startInstant()
                         .orElse(Instant.EPOCH)
                         .getEpochSecond();
-        URI uri = callback;
+        URI uri = webServer.getCallback();
         if (preferJmx && jmxPort > 0) {
             uri =
                     URI.create(
@@ -255,6 +257,7 @@ class Registration {
 
         enum State {
             REGISTERED,
+            PUBLISHED,
             UNREGISTERED,
             REFRESHED,
         }

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -262,6 +262,7 @@ class Registration {
             return CompletableFuture.completedFuture(null);
         }
         return cryostat.deleteCredentials(this.credentialId)
+                .thenRun(() -> this.credentialId = -1)
                 .thenCompose(v -> cryostat.deregister(pluginInfo))
                 .handle(
                         (n, t) -> {

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -79,7 +79,7 @@ class Registration {
     private final PluginInfo pluginInfo = new PluginInfo();
     private final Set<Consumer<RegistrationEvent>> listeners = new HashSet<>();
 
-    private int credentialId = -1;
+    private volatile int credentialId = -1;
 
     Registration(
             ScheduledExecutorService executor,

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -222,20 +222,20 @@ class WebServer implements Consumer<RegistrationEvent> {
 
         synchronized boolean checkUserInfo(String username, String password)
                 throws NoSuchAlgorithmException {
-            byte[] passHash =
-                    MessageDigest.getInstance("SHA-256")
-                            .digest(password.getBytes(StandardCharsets.UTF_8));
             return Objects.equals(username, Credentials.user)
-                    && Arrays.equals(passHash, this.passHash);
+                    && Arrays.equals(hash(password), this.passHash);
         }
 
         synchronized void regenerate() throws NoSuchAlgorithmException {
             String pass =
                     RandomStringUtils.random(32, 33, 126, false, false, null, new SecureRandom());
             this.pass = pass.toCharArray();
-            this.passHash =
-                    MessageDigest.getInstance("SHA-256")
-                            .digest(pass.getBytes(StandardCharsets.UTF_8));
+            this.passHash = hash(pass);
+        }
+
+        private byte[] hash(String pass) throws NoSuchAlgorithmException {
+            return MessageDigest.getInstance("SHA-256")
+                    .digest(pass.getBytes(StandardCharsets.UTF_8));
         }
 
         synchronized void clear() {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -204,7 +204,7 @@ class WebServer implements Consumer<RegistrationEvent> {
         }
 
         @Override
-        public synchronized boolean checkCredentials(String username, String password) {
+        public boolean checkCredentials(String username, String password) {
             try {
                 return WebServer.this.credentials.checkUserInfo(username, password);
             } catch (NoSuchAlgorithmException e) {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -203,18 +203,33 @@ class WebServer {
 
         synchronized void regenerate() throws NoSuchAlgorithmException {
             this.clear();
+            final SecureRandom r = SecureRandom.getInstanceStrong();
             final int len = 24;
+
             this.pass = new char[len];
-            this.pass[0] = randomSymbol();
-            this.pass[1] = randomSymbol();
-            this.pass[2] = randomNumeric();
-            this.pass[3] = randomNumeric();
-            for (int i = 4; i < len; i++) {
-                pass[i] = randomAlphabetical(SecureRandom.getInstanceStrong().nextDouble() > 0.5);
+            int idx = 0;
+
+            // 2-5 special characters
+            for (int i = 0; i < r.nextInt(3) + 2; i++) {
+                this.pass[i] = randomSymbol();
+                idx++;
             }
+
+            // 2-5 numeric characters
+            for (int i = idx; i < r.nextInt(3) + 2; i++) {
+                this.pass[i] = randomNumeric();
+                idx++;
+            }
+
+            // remaining slots alphabetical characters of roughly even upper and lower case
+            for (int i = idx; i < len; i++) {
+                pass[i] = randomAlphabetical(r.nextDouble() > 0.5);
+            }
+
+            // randomly shuffle the characters
             // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
             for (int i = this.pass.length - 1; i > 1; i--) {
-                int j = SecureRandom.getInstanceStrong().nextInt(i);
+                int j = r.nextInt(i);
                 char c = this.pass[i];
                 this.pass[i] = this.pass[j];
                 this.pass[j] = c;

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -239,7 +239,7 @@ class WebServer {
             return user;
         }
 
-        byte[] passBytes() {
+        byte[] pass() {
             return pass;
         }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -239,7 +239,7 @@ class WebServer {
             return user;
         }
 
-        byte[] pass() {
+        synchronized byte[] pass() {
             return pass;
         }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -230,10 +230,8 @@ class WebServer implements Consumer<RegistrationEvent> {
         }
 
         synchronized void regenerate() throws NoSuchAlgorithmException {
-            String set = "abcdefghijklmnopqrstuvwxyz-_=[].0123456789";
             String pass =
-                    RandomStringUtils.random(
-                            16, 0, set.length(), true, true, set.toCharArray(), new SecureRandom());
+                    RandomStringUtils.random(32, 33, 126, false, false, null, new SecureRandom());
             this.pass = pass.toCharArray();
             this.passHash =
                     MessageDigest.getInstance("SHA-256")

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -243,32 +243,32 @@ class WebServer {
             return pass;
         }
 
-        private byte randomAlphabetical(boolean upperCase) throws NoSuchAlgorithmException {
+        synchronized void clear() {
+            Arrays.fill(this.pass, (byte) 0);
+        }
+
+        private static byte randomAlphabetical(boolean upperCase) throws NoSuchAlgorithmException {
             return randomChar(upperCase ? 'A' : 'a', 26);
         }
 
-        private byte randomNumeric() throws NoSuchAlgorithmException {
+        private static byte randomNumeric() throws NoSuchAlgorithmException {
             return randomChar('0', 10);
         }
 
-        private byte randomSymbol() throws NoSuchAlgorithmException {
+        private static byte randomSymbol() throws NoSuchAlgorithmException {
             return randomChar(33, 14);
         }
 
-        private byte randomChar(int offset, int range) throws NoSuchAlgorithmException {
+        private static byte randomChar(int offset, int range) throws NoSuchAlgorithmException {
             return (byte) (SecureRandom.getInstanceStrong().nextInt(range) + offset);
         }
 
-        private byte[] hash(String pass) throws NoSuchAlgorithmException {
+        private static byte[] hash(String pass) throws NoSuchAlgorithmException {
             return hash(pass.getBytes(StandardCharsets.UTF_8));
         }
 
-        private byte[] hash(byte[] bytes) throws NoSuchAlgorithmException {
+        private static byte[] hash(byte[] bytes) throws NoSuchAlgorithmException {
             return MessageDigest.getInstance("SHA-256").digest(bytes);
-        }
-
-        synchronized void clear() {
-            Arrays.fill(this.pass, (byte) 0);
         }
     }
 }

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -39,22 +39,41 @@ package io.cryostat.agent;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Arrays;
+import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Consumer;
 
+import io.cryostat.agent.Registration.RegistrationEvent;
+
+import com.sun.net.httpserver.BasicAuthenticator;
+import com.sun.net.httpserver.Filter;
+import com.sun.net.httpserver.HttpContext;
 import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import dagger.Lazy;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.http.HttpStatus;
+import org.apache.http.client.utils.URIBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-class WebServer {
+class WebServer implements Consumer<RegistrationEvent> {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final ScheduledExecutorService executor;
     private final String host;
     private final int port;
+    private Credentials credentials;
+    private final URI callback;
     private final Lazy<Registration> registration;
     private HttpServer http;
 
@@ -62,36 +81,76 @@ class WebServer {
             ScheduledExecutorService executor,
             String host,
             int port,
+            URI callback,
             Lazy<Registration> registration) {
         this.executor = executor;
         this.host = host;
         this.port = port;
+        this.callback = callback;
         this.registration = registration;
     }
 
-    void start() throws IOException {
+    URI getCallback() throws URISyntaxException {
+        return new URIBuilder(callback)
+                .setUserInfo(credentials.user, new String(credentials.pass))
+                .build();
+    }
+
+    void start() throws IOException, NoSuchAlgorithmException {
         if (this.http != null) {
             stop();
         }
-        this.http = com.sun.net.httpserver.HttpServer.create(new InetSocketAddress(host, port), 0);
+        this.http = HttpServer.create(new InetSocketAddress(host, port), 0);
 
         this.http.setExecutor(executor);
-        this.http
-                .createContext("/")
-                .setHandler(
+        this.credentials = Authenticators.INSTANCE.authenticator.regenerate();
+
+        HttpContext pingCtx =
+                this.http.createContext(
+                        "/",
                         new HttpHandler() {
                             @Override
                             public void handle(HttpExchange exchange) throws IOException {
                                 String mtd = exchange.getRequestMethod();
-                                if ("POST".equals(mtd)) {
-                                    executor.execute(registration.get()::tryRegister);
+                                switch (mtd) {
+                                    case "POST":
+                                        executor.execute(registration.get()::tryRegister);
+                                        exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                                        exchange.close();
+                                        break;
+                                    case "GET":
+                                        exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                                        exchange.close();
+                                        break;
+                                    default:
+                                        exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
+                                        exchange.close();
+                                        break;
                                 }
-                                log.trace("{} {}: 204", mtd, exchange.getRequestURI());
-
-                                exchange.sendResponseHeaders(204, -1);
-                                exchange.close();
                             }
                         });
+        pingCtx.setAuthenticator(Authenticators.INSTANCE.authenticator);
+        pingCtx.getFilters()
+                .add(
+                        Filter.beforeHandler(
+                                "beforeLog",
+                                exchange ->
+                                        log.info(
+                                                "{} {}",
+                                                exchange.getRequestMethod(),
+                                                exchange.getRequestURI().getPath())));
+        pingCtx.getFilters()
+                .add(
+                        Filter.afterHandler(
+                                "afterLog",
+                                exchange ->
+                                        log.info(
+                                                "{} {} : {}",
+                                                exchange.getRequestMethod(),
+                                                exchange.getRequestURI().getPath(),
+                                                exchange.getResponseCode())));
+
+        this.registration.get().addRegistrationListener(this);
 
         this.http.start();
     }
@@ -100,6 +159,93 @@ class WebServer {
         if (this.http != null) {
             this.http.stop(0);
             this.http = null;
+        }
+    }
+
+    @Override
+    public void accept(RegistrationEvent t) {
+        switch (t.state) {
+            case PUBLISHED:
+                // once we have successfully registered and published, the Cryostat server has been
+                // fully informed of our presence and the credentials we expect to be presented on
+                // HTTP API communications back to us. So, we clear these credentials out of memory
+                // - the username and a hash of the password are held, but the password itself is
+                // dropped.
+                this.credentials.clear();
+                break;
+            case UNREGISTERED:
+                break;
+            case REFRESHED:
+                break;
+            case REGISTERED:
+                break;
+            default:
+                break;
+        }
+    }
+
+    private enum Authenticators {
+        INSTANCE(new AgentAuthenticator());
+
+        private final AgentAuthenticator authenticator;
+
+        Authenticators(AgentAuthenticator authenticator) {
+            this.authenticator = authenticator;
+        }
+    }
+
+    private static class AgentAuthenticator extends BasicAuthenticator {
+
+        private final Logger log = LoggerFactory.getLogger(getClass());
+        private final MessageDigest md;
+        private String user;
+        private byte[] passHash;
+
+        public AgentAuthenticator() {
+            super("cryostat-agent");
+            try {
+                this.md = MessageDigest.getInstance("SHA-256");
+            } catch (NoSuchAlgorithmException nsae) {
+                log.error("No such algorithm", nsae);
+                throw new RuntimeException(nsae);
+            }
+        }
+
+        @Override
+        public synchronized boolean checkCredentials(String username, String password) {
+            byte[] passHash = md.digest(password.getBytes(StandardCharsets.UTF_8));
+            return Objects.equals(username, this.user) && Arrays.equals(passHash, this.passHash);
+        }
+
+        private synchronized Credentials regenerate() {
+            String user = "agent";
+            String set = "abcdefghijklmnopqrstuvwxyz-_=[].0123456789";
+            String pass =
+                    RandomStringUtils.random(
+                            16, 0, set.length(), true, true, set.toCharArray(), new SecureRandom());
+            Credentials c = new Credentials(user, pass.toCharArray());
+            this.user = user;
+            this.passHash = md.digest(pass.getBytes(StandardCharsets.UTF_8));
+            return c;
+        }
+    }
+
+    static class Credentials {
+        String user;
+        char[] pass;
+
+        Credentials(String user, char[] pass) {
+            this.user = user;
+            this.pass = pass;
+        }
+
+        void clear() {
+            if (pass != null) {
+                for (int i = 0; i < pass.length; i++) {
+                    pass[i] = '\0';
+                }
+                pass = null;
+            }
         }
     }
 }

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -207,23 +207,22 @@ class WebServer {
             final int len = 24;
 
             this.pass = new char[len];
-            int idx = 0;
 
-            // 2-5 special characters
-            for (int i = 0; i < r.nextInt(3) + 2; i++) {
-                this.pass[i] = randomSymbol();
-                idx++;
-            }
+            // guarantee at least one character from each class
+            this.pass[0] = randomSymbol();
+            this.pass[1] = randomNumeric();
+            this.pass[2] = randomAlphabetical(r.nextBoolean());
 
-            // 2-5 numeric characters
-            for (int i = idx; i < r.nextInt(3) + 2; i++) {
-                this.pass[i] = randomNumeric();
-                idx++;
-            }
-
-            // remaining slots alphabetical characters of roughly even upper and lower case
-            for (int i = idx; i < len; i++) {
-                pass[i] = randomAlphabetical(r.nextDouble() > 0.5);
+            // fill remaining slots with randomly assigned characters across classes
+            for (int i = 3; i < len; i++) {
+                int s = r.nextInt(3);
+                if (s == 0) {
+                    this.pass[i] = randomSymbol();
+                } else if (s == 1) {
+                    this.pass[i] = randomNumeric();
+                } else {
+                    this.pass[i] = randomAlphabetical(r.nextBoolean());
+                }
             }
 
             // randomly shuffle the characters

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -56,7 +56,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import dagger.Lazy;
-import org.apache.commons.lang3.ArrayUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -213,7 +212,13 @@ class WebServer {
             for (int i = 4; i < len; i++) {
                 pass[i] = randomAlphabetical(SecureRandom.getInstanceStrong().nextDouble() > 0.5);
             }
-            ArrayUtils.shuffle(this.pass);
+            // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
+            for (int i = this.pass.length - 1; i > 1; i--) {
+                int j = SecureRandom.getInstanceStrong().nextInt(i);
+                char c = this.pass[i];
+                this.pass[i] = this.pass[j];
+                this.pass[j] = c;
+            }
 
             this.passHash = hash(pass);
         }

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -14,6 +14,7 @@ cryostat.agent.realm=
 
 cryostat.agent.exit.signals=INT,TERM
 cryostat.agent.registration.retry-ms=5000
+cryostat.agent.registration.prefer-jmx=false
 cryostat.agent.exit.deregistration.timeout-ms=3000
 
 cryostat.agent.harvester.period-ms=-1


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat-agent/issues/63
Depends on https://github.com/cryostatio/cryostat/pull/1377 (so the backend knows how to pass the challenge)

~~In this PR the Agent generates Basic auth credentials to secure its built-in HTTP webserver. Incoming HTTP requests to the webserver must pass an HTTP Basic Authentication challenge. The credentials use a fixed username and a randomly generated password string. The password string is held in memory only long enough for the Agent to complete registration and publication of itself to the Cryostat backend. After that point, the password is blanked out from memory and only a hash of the password retained to compare against incoming HTTP requests. This PR also causes the Agent to prefer to register itself with the HTTP Agent connection URL rather than a JMX Service URL, but there is a config property to prefer using a JMX Service URL (contingent on JMX being detected enabled on the host JVM).~~

Updated: https://github.com/cryostatio/cryostat/pull/1377#issuecomment-1444329903
The username and password generation and clearing behaviour is still the same, however, rather than passing these details in the callback URI userinfo, they are stored in the Cryostat server's encrypted credentials database. There is a userinfo reference format that specifically tells Cryostat to look up the credentials in that database rather than reading them literally from the URI.

This is a precursor to expanding the Agent HTTP interface to implement a subset of Cryostat API actions, ex. retrieving the list of active recordings, dynamically starting recordings, etc. These actions should obviously require clients to pass an authentication challenge.