### PR TITLE
ci(deps): configure Dependabot to read from GH packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  maven-github:
+    type: maven-repository
+    url: https://maven.pkg.github.com/cryostatio/cryostat-core
+    username: dummy
+    password: ${{secrets.DEPENDABOT_READ_GHCR}}
 updates:
   - package-ecosystem: "maven"
     directory: "/"
@@ -11,3 +17,5 @@ updates:
       - "chore"
       - "safe-to-test"
     open-pull-requests-limit: 10
+    registries:
+      - "maven-github"


### PR DESCRIPTION
To handle cryostat-core updates, as done in: https://github.com/cryostatio/cryostat-reports/pull/76.

Related to: #14 