### PR TITLE
chore(ci): use temurin distribution jdk

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,7 +25,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: '11'
-        distribution: 'adopt'
+        distribution: 'temurin'
     - name: maven-settings
       uses: s4u/maven-settings-action@v2
       with:


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/1401

See https://github.com/actions/setup-java#supported-distributions

Update ci to use `temurin` jdk.