### PR TITLE
feat(api): remote readonly accesses

### DIFF
--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -105,12 +105,13 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static WebServer provideWebServer(
+            ObjectMapper mapper,
             Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
             Lazy<Registration> registration) {
-        return new WebServer(cryostat, executor, host, port, registration);
+        return new WebServer(mapper, cryostat, executor, host, port, registration);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -109,13 +109,12 @@ public abstract class MainModule {
     @Singleton
     public static WebServer provideWebServer(
             Lazy<Set<RemoteContext>> remoteContexts,
-            ObjectMapper mapper,
             Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
             Lazy<Registration> registration) {
-        return new WebServer(remoteContexts, mapper, cryostat, executor, host, port, registration);
+        return new WebServer(remoteContexts, cryostat, executor, host, port, registration);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -55,6 +55,8 @@ import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509TrustManager;
 
 import io.cryostat.agent.Harvester.RecordingSettings;
+import io.cryostat.agent.remote.RemoteContext;
+import io.cryostat.agent.remote.RemoteModule;
 import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
@@ -76,6 +78,7 @@ import org.slf4j.LoggerFactory;
 @Module(
         includes = {
             ConfigModule.class,
+            RemoteModule.class,
         })
 public abstract class MainModule {
 
@@ -105,13 +108,14 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static WebServer provideWebServer(
+            Lazy<Set<RemoteContext>> remoteContexts,
             ObjectMapper mapper,
             Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
             Lazy<Registration> registration) {
-        return new WebServer(mapper, cryostat, executor, host, port, registration);
+        return new WebServer(remoteContexts, mapper, cryostat, executor, host, port, registration);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -369,16 +369,6 @@ class WebServer {
             log.error("Could not compute own jvmId!", e);
         }
 
-        try {
-            log.info(mapper.writeValueAsString(runtimeAttrs));
-            log.info(mapper.writeValueAsString(memory));
-            log.info(mapper.writeValueAsString(threads));
-            log.info(mapper.writeValueAsString(os));
-            log.info(jvmId);
-        } catch (JsonProcessingException jpe) {
-            log.error("couldn't serialize", jpe);
-        }
-
         return new MBeanMetrics(runtime, memory, threads, os, jvmId);
     }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -41,7 +41,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
-import java.io.PrintWriter;
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
 import java.lang.management.OperatingSystemMXBean;
@@ -165,13 +164,10 @@ class WebServer {
                                     case "GET":
                                         try {
                                             MBeanMetrics metrics = getMbeanMetrics();
-                                            String json = mapper.writeValueAsString(metrics);
-                                            log.info(json);
                                             exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
                                             try (OutputStream response =
-                                                            exchange.getResponseBody();
-                                                    PrintWriter pw = new PrintWriter(response)) {
-                                                pw.write(json);
+                                                    exchange.getResponseBody()) {
+                                                mapper.writeValue(response, metrics);
                                             }
                                         } catch (Exception e) {
                                             log.error("mbean serialization failure", e);

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -347,12 +347,12 @@ class WebServer {
         if (osBean instanceof UnixOperatingSystemMXBean) {
             UnixOperatingSystemMXBean unix = (UnixOperatingSystemMXBean) osBean;
             safeStore("CommittedVirtualMemorySize", osAttrs, unix::getCommittedVirtualMemorySize);
-            safeStore("FreePhysicalMemorySize", osAttrs, unix::getFreeMemorySize);
+            safeStore("FreePhysicalMemorySize", osAttrs, unix::getFreePhysicalMemorySize);
             safeStore("FreeSwapSpaceSize", osAttrs, unix::getFreeSwapSpaceSize);
             safeStore("ProcessCpuLoad", osAttrs, unix::getProcessCpuLoad);
             safeStore("ProcessCpuTime", osAttrs, unix::getProcessCpuTime);
-            safeStore("SystemCpuLoad", osAttrs, unix::getCpuLoad);
-            safeStore("TotalPhysicalMemorySize", osAttrs, unix::getTotalMemorySize);
+            safeStore("SystemCpuLoad", osAttrs, unix::getSystemCpuLoad);
+            safeStore("TotalPhysicalMemorySize", osAttrs, unix::getTotalPhysicalMemorySize);
             safeStore("TotalSwapSpaceSize", osAttrs, unix::getTotalSwapSpaceSize);
         }
         OperatingSystemMetrics os = new OperatingSystemMetrics(osAttrs);

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -37,15 +37,7 @@
  */
 package io.cryostat.agent;
 
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.management.ManagementFactory;
-import java.lang.management.MemoryMXBean;
-import java.lang.management.OperatingSystemMXBean;
-import java.lang.management.RuntimeMXBean;
-import java.lang.management.ThreadMXBean;
 import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -54,22 +46,14 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.concurrent.Callable;
+import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 
-import io.cryostat.core.net.MBeanMetrics;
-import io.cryostat.core.net.MemoryMetrics;
-import io.cryostat.core.net.OperatingSystemMetrics;
-import io.cryostat.core.net.RuntimeMetrics;
-import io.cryostat.core.net.ThreadMetrics;
+import io.cryostat.agent.remote.RemoteContext;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.sun.management.UnixOperatingSystemMXBean;
 import com.sun.net.httpserver.BasicAuthenticator;
 import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpContext;
@@ -77,7 +61,6 @@ import com.sun.net.httpserver.HttpExchange;
 import com.sun.net.httpserver.HttpHandler;
 import com.sun.net.httpserver.HttpServer;
 import dagger.Lazy;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -86,6 +69,7 @@ class WebServer {
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
+    private final Lazy<Set<RemoteContext>> remoteContexts;
     private final ObjectMapper mapper;
     private final Lazy<CryostatClient> cryostat;
     private final ScheduledExecutorService executor;
@@ -96,12 +80,14 @@ class WebServer {
     private HttpServer http;
 
     WebServer(
+            Lazy<Set<RemoteContext>> remoteContexts,
             ObjectMapper mapper,
             Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             String host,
             int port,
             Lazy<Registration> registration) {
+        this.remoteContexts = remoteContexts;
         this.mapper = mapper;
         this.cryostat = cryostat;
         this.executor = executor;
@@ -123,7 +109,6 @@ class WebServer {
         this.http.setExecutor(executor);
 
         List<HttpContext> ctxs = new ArrayList<>();
-
         ctxs.add(
                 this.http.createContext(
                         "/",
@@ -151,36 +136,10 @@ class WebServer {
                                 }
                             }
                         }));
-
-        ctxs.add(
-                this.http.createContext(
-                        "/mbean-metrics",
-                        new HttpHandler() {
-                            @Override
-                            public void handle(HttpExchange exchange) throws IOException {
-                                String mtd = exchange.getRequestMethod();
-                                switch (mtd) {
-                                    case "GET":
-                                        try {
-                                            MBeanMetrics metrics = getMbeanMetrics();
-                                            exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
-                                            try (OutputStream response =
-                                                    exchange.getResponseBody()) {
-                                                mapper.writeValue(response, metrics);
-                                            }
-                                        } catch (Exception e) {
-                                            log.error("mbean serialization failure", e);
-                                        } finally {
-                                            exchange.close();
-                                        }
-                                        break;
-                                    default:
-                                        exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
-                                        exchange.close();
-                                        break;
-                                }
-                            }
-                        }));
+        ctxs.addAll(
+                remoteContexts.get().stream()
+                        .map(rc -> this.http.createContext(rc.path(), rc::handle))
+                        .toList());
 
         ctxs.forEach(ctx -> ctx.setAuthenticator(new AgentAuthenticator()));
         ctxs.forEach(
@@ -234,141 +193,6 @@ class WebServer {
                     .thenAccept(i -> log.info("Defined credentials with id {}", i))
                     .thenRun(this.credentials::clear);
         }
-    }
-
-    private <T> void safeStore(String key, Map<String, Object> map, Callable<T> fn) {
-        try {
-            map.put(key, fn.call());
-        } catch (Exception e) {
-            log.warn("Call failed", e);
-        }
-    }
-
-    private MBeanMetrics getMbeanMetrics() {
-        // TODO refactor, extract into -core library?
-        RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
-        Map<String, Object> runtimeAttrs = new HashMap<>();
-        safeStore("BootClassPath", runtimeAttrs, runtimeBean::getBootClassPath);
-        safeStore("ClassPath", runtimeAttrs, runtimeBean::getClassPath);
-        safeStore(
-                "InputArguments",
-                runtimeAttrs,
-                () -> runtimeBean.getInputArguments().toArray(new String[0]));
-        safeStore("LibraryPath", runtimeAttrs, runtimeBean::getLibraryPath);
-        safeStore("ManagementSpecVersion", runtimeAttrs, runtimeBean::getManagementSpecVersion);
-        safeStore("Name", runtimeAttrs, runtimeBean::getName);
-        safeStore("SpecName", runtimeAttrs, runtimeBean::getSpecName);
-        safeStore("SpecVersion", runtimeAttrs, runtimeBean::getSpecVersion);
-        safeStore("SystemProperties", runtimeAttrs, runtimeBean::getSystemProperties);
-        safeStore("StartTime", runtimeAttrs, runtimeBean::getStartTime);
-        safeStore("Uptime", runtimeAttrs, runtimeBean::getUptime);
-        safeStore("VmName", runtimeAttrs, runtimeBean::getVmName);
-        safeStore("VmVendor", runtimeAttrs, runtimeBean::getVmVendor);
-        safeStore("VmVersion", runtimeAttrs, runtimeBean::getVmVersion);
-        safeStore("BootClassPathSupported", runtimeAttrs, runtimeBean::isBootClassPathSupported);
-        RuntimeMetrics runtime = new RuntimeMetrics(runtimeAttrs);
-
-        MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
-        Map<String, Object> memoryAttrs = new HashMap<>();
-        safeStore("HeapMemoryUsage", memoryAttrs, memoryBean::getHeapMemoryUsage);
-        safeStore("NonHeapMemoryUsage", memoryAttrs, memoryBean::getNonHeapMemoryUsage);
-        safeStore(
-                "ObjectPendingFinalizationCount",
-                memoryAttrs,
-                memoryBean::getObjectPendingFinalizationCount);
-        // TODO are these inferred calculations correct (ie do they match what the bean attributes
-        // say)?
-        safeStore(
-                "FreeHeapMemory",
-                memoryAttrs,
-                () ->
-                        memoryBean.getHeapMemoryUsage().getCommitted()
-                                - memoryBean.getHeapMemoryUsage().getUsed());
-        safeStore(
-                "FreeNonHeapMemory",
-                memoryAttrs,
-                () ->
-                        memoryBean.getNonHeapMemoryUsage().getCommitted()
-                                - memoryBean.getNonHeapMemoryUsage().getUsed());
-        safeStore(
-                "HeapMemoryUsagePercent",
-                memoryAttrs,
-                () ->
-                        ((double) memoryBean.getHeapMemoryUsage().getUsed()
-                                / (double) memoryBean.getHeapMemoryUsage().getCommitted()));
-        safeStore("Verbose", memoryAttrs, memoryBean::isVerbose);
-        MemoryMetrics memory = new MemoryMetrics(memoryAttrs);
-
-        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
-        Map<String, Object> threadAttrs = new HashMap<>();
-        safeStore("AllThreadIds", threadAttrs, threadBean::getAllThreadIds);
-        safeStore("CurrentThreadCpuTime", threadAttrs, threadBean::getCurrentThreadCpuTime);
-        safeStore("CurrentThreadUserTime", threadAttrs, threadBean::getCurrentThreadUserTime);
-        safeStore("DaemonThreadCount", threadAttrs, threadBean::getDaemonThreadCount);
-        safeStore("PeakThreadCount", threadAttrs, threadBean::getPeakThreadCount);
-        safeStore("ThreadCount", threadAttrs, threadBean::getThreadCount);
-        safeStore("TotalStartedThreadCount", threadAttrs, threadBean::getTotalStartedThreadCount);
-        safeStore(
-                "CurrentThreadCpuTimeSupported",
-                threadAttrs,
-                threadBean::isCurrentThreadCpuTimeSupported);
-        safeStore(
-                "ObjectMonitorUsageSupported",
-                threadAttrs,
-                threadBean::isObjectMonitorUsageSupported);
-        safeStore(
-                "SynchronizerUsageSupported",
-                threadAttrs,
-                threadBean::isSynchronizerUsageSupported);
-        safeStore(
-                "ThreadContentionMonitoringEnabled",
-                threadAttrs,
-                threadBean::isThreadContentionMonitoringEnabled);
-        safeStore(
-                "ThreadContentionMonitoringSupported",
-                threadAttrs,
-                threadBean::isThreadContentionMonitoringSupported);
-        safeStore("ThreadCpuTimeEnabled", threadAttrs, threadBean::isThreadCpuTimeEnabled);
-        safeStore("ThreadCpuTimeSupported", threadAttrs, threadBean::isThreadCpuTimeSupported);
-        ThreadMetrics threads = new ThreadMetrics(threadAttrs);
-
-        OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
-        Map<String, Object> osAttrs = new HashMap<>();
-        safeStore("Arch", osAttrs, osBean::getArch);
-        safeStore("AvailableProcessors", osAttrs, osBean::getAvailableProcessors);
-        safeStore("Name", osAttrs, osBean::getName);
-        safeStore("SystemLoadAverage", osAttrs, osBean::getSystemLoadAverage);
-        safeStore("Version", osAttrs, osBean::getVersion);
-        if (osBean instanceof UnixOperatingSystemMXBean) {
-            UnixOperatingSystemMXBean unix = (UnixOperatingSystemMXBean) osBean;
-            safeStore("CommittedVirtualMemorySize", osAttrs, unix::getCommittedVirtualMemorySize);
-            safeStore("FreePhysicalMemorySize", osAttrs, unix::getFreePhysicalMemorySize);
-            safeStore("FreeSwapSpaceSize", osAttrs, unix::getFreeSwapSpaceSize);
-            safeStore("ProcessCpuLoad", osAttrs, unix::getProcessCpuLoad);
-            safeStore("ProcessCpuTime", osAttrs, unix::getProcessCpuTime);
-            safeStore("SystemCpuLoad", osAttrs, unix::getSystemCpuLoad);
-            safeStore("TotalPhysicalMemorySize", osAttrs, unix::getTotalPhysicalMemorySize);
-            safeStore("TotalSwapSpaceSize", osAttrs, unix::getTotalSwapSpaceSize);
-        }
-        OperatingSystemMetrics os = new OperatingSystemMetrics(osAttrs);
-
-        String jvmId = null;
-        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
-                DataOutputStream dos = new DataOutputStream(baos)) {
-            dos.writeUTF(runtime.getClassPath());
-            dos.writeUTF(runtime.getName());
-            dos.writeUTF(Arrays.toString(runtime.getInputArguments()));
-            dos.writeUTF(runtime.getLibraryPath());
-            dos.writeUTF(runtime.getVmVendor());
-            dos.writeUTF(runtime.getVmVersion());
-            dos.writeLong(runtime.getStartTime());
-            byte[] hash = DigestUtils.sha256(baos.toByteArray());
-            jvmId = new String(Base64.getUrlEncoder().encode(hash), StandardCharsets.UTF_8).trim();
-        } catch (IOException e) {
-            log.error("Could not compute own jvmId!", e);
-        }
-
-        return new MBeanMetrics(runtime, memory, threads, os, jvmId);
     }
 
     private class AgentAuthenticator extends BasicAuthenticator {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -68,7 +68,6 @@ import io.cryostat.core.net.OperatingSystemMetrics;
 import io.cryostat.core.net.RuntimeMetrics;
 import io.cryostat.core.net.ThreadMetrics;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.management.UnixOperatingSystemMXBean;
 import com.sun.net.httpserver.BasicAuthenticator;

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -52,7 +52,6 @@ import java.util.concurrent.ScheduledExecutorService;
 
 import io.cryostat.agent.remote.RemoteContext;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.BasicAuthenticator;
 import com.sun.net.httpserver.Filter;
 import com.sun.net.httpserver.HttpContext;
@@ -68,7 +67,6 @@ class WebServer {
     private final Logger log = LoggerFactory.getLogger(getClass());
 
     private final Lazy<Set<RemoteContext>> remoteContexts;
-    private final ObjectMapper mapper;
     private final Lazy<CryostatClient> cryostat;
     private final ScheduledExecutorService executor;
     private final String host;
@@ -82,14 +80,12 @@ class WebServer {
 
     WebServer(
             Lazy<Set<RemoteContext>> remoteContexts,
-            ObjectMapper mapper,
             Lazy<CryostatClient> cryostat,
             ScheduledExecutorService executor,
             String host,
             int port,
             Lazy<Registration> registration) {
         this.remoteContexts = remoteContexts;
-        this.mapper = mapper;
         this.cryostat = cryostat;
         this.executor = executor;
         this.host = host;

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -77,6 +77,7 @@ class WebServer {
     private final Lazy<Registration> registration;
     private HttpServer http;
 
+    private final AgentAuthenticator agentAuthenticator;
     private final RequestLoggingFilter requestLoggingFilter;
 
     WebServer(
@@ -96,6 +97,7 @@ class WebServer {
         this.credentials = new Credentials();
         this.registration = registration;
 
+        this.agentAuthenticator = new AgentAuthenticator();
         this.requestLoggingFilter = new RequestLoggingFilter();
     }
 
@@ -114,7 +116,7 @@ class WebServer {
         mergedContexts.forEach(
                 rc -> {
                     HttpContext ctx = this.http.createContext(rc.path(), rc::handle);
-                    ctx.setAuthenticator(new AgentAuthenticator());
+                    ctx.setAuthenticator(agentAuthenticator);
                     ctx.getFilters().add(requestLoggingFilter);
                 });
 

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -90,7 +90,7 @@ class MBeanContext implements RemoteContext {
         switch (mtd) {
             case "GET":
                 try {
-                    MBeanMetrics metrics = getMbeanMetrics();
+                    MBeanMetrics metrics = getMBeanMetrics();
                     exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
                     try (OutputStream response = exchange.getResponseBody()) {
                         mapper.writeValue(response, metrics);
@@ -108,7 +108,7 @@ class MBeanContext implements RemoteContext {
         }
     }
 
-    private MBeanMetrics getMbeanMetrics() {
+    private MBeanMetrics getMBeanMetrics() {
         // TODO refactor, extract into -core library?
         RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
         Map<String, Object> runtimeAttrs = new HashMap<>();

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.agent.remote;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.Callable;
+
+import javax.inject.Inject;
+
+import io.cryostat.core.net.MBeanMetrics;
+import io.cryostat.core.net.MemoryMetrics;
+import io.cryostat.core.net.OperatingSystemMetrics;
+import io.cryostat.core.net.RuntimeMetrics;
+import io.cryostat.core.net.ThreadMetrics;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.management.UnixOperatingSystemMXBean;
+import com.sun.net.httpserver.HttpExchange;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class MBeanContext implements RemoteContext {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final ObjectMapper mapper;
+
+    @Inject
+    MBeanContext(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String path() {
+        return "/mbean-metrics";
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String mtd = exchange.getRequestMethod();
+        switch (mtd) {
+            case "GET":
+                try {
+                    MBeanMetrics metrics = getMbeanMetrics();
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                    try (OutputStream response = exchange.getResponseBody()) {
+                        mapper.writeValue(response, metrics);
+                    }
+                } catch (Exception e) {
+                    log.error("mbean serialization failure", e);
+                } finally {
+                    exchange.close();
+                }
+                break;
+            default:
+                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
+                exchange.close();
+                break;
+        }
+    }
+
+    private MBeanMetrics getMbeanMetrics() {
+        // TODO refactor, extract into -core library?
+        RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+        Map<String, Object> runtimeAttrs = new HashMap<>();
+        safeStore("BootClassPath", runtimeAttrs, runtimeBean::getBootClassPath);
+        safeStore("ClassPath", runtimeAttrs, runtimeBean::getClassPath);
+        safeStore(
+                "InputArguments",
+                runtimeAttrs,
+                () -> runtimeBean.getInputArguments().toArray(new String[0]));
+        safeStore("LibraryPath", runtimeAttrs, runtimeBean::getLibraryPath);
+        safeStore("ManagementSpecVersion", runtimeAttrs, runtimeBean::getManagementSpecVersion);
+        safeStore("Name", runtimeAttrs, runtimeBean::getName);
+        safeStore("SpecName", runtimeAttrs, runtimeBean::getSpecName);
+        safeStore("SpecVersion", runtimeAttrs, runtimeBean::getSpecVersion);
+        safeStore("SystemProperties", runtimeAttrs, runtimeBean::getSystemProperties);
+        safeStore("StartTime", runtimeAttrs, runtimeBean::getStartTime);
+        safeStore("Uptime", runtimeAttrs, runtimeBean::getUptime);
+        safeStore("VmName", runtimeAttrs, runtimeBean::getVmName);
+        safeStore("VmVendor", runtimeAttrs, runtimeBean::getVmVendor);
+        safeStore("VmVersion", runtimeAttrs, runtimeBean::getVmVersion);
+        safeStore("BootClassPathSupported", runtimeAttrs, runtimeBean::isBootClassPathSupported);
+        RuntimeMetrics runtime = new RuntimeMetrics(runtimeAttrs);
+
+        MemoryMXBean memoryBean = ManagementFactory.getMemoryMXBean();
+        Map<String, Object> memoryAttrs = new HashMap<>();
+        safeStore("HeapMemoryUsage", memoryAttrs, memoryBean::getHeapMemoryUsage);
+        safeStore("NonHeapMemoryUsage", memoryAttrs, memoryBean::getNonHeapMemoryUsage);
+        safeStore(
+                "ObjectPendingFinalizationCount",
+                memoryAttrs,
+                memoryBean::getObjectPendingFinalizationCount);
+        // TODO are these inferred calculations correct (ie do they match what the bean attributes
+        // say)?
+        safeStore(
+                "FreeHeapMemory",
+                memoryAttrs,
+                () ->
+                        memoryBean.getHeapMemoryUsage().getCommitted()
+                                - memoryBean.getHeapMemoryUsage().getUsed());
+        safeStore(
+                "FreeNonHeapMemory",
+                memoryAttrs,
+                () ->
+                        memoryBean.getNonHeapMemoryUsage().getCommitted()
+                                - memoryBean.getNonHeapMemoryUsage().getUsed());
+        safeStore(
+                "HeapMemoryUsagePercent",
+                memoryAttrs,
+                () ->
+                        ((double) memoryBean.getHeapMemoryUsage().getUsed()
+                                / (double) memoryBean.getHeapMemoryUsage().getCommitted()));
+        safeStore("Verbose", memoryAttrs, memoryBean::isVerbose);
+        MemoryMetrics memory = new MemoryMetrics(memoryAttrs);
+
+        ThreadMXBean threadBean = ManagementFactory.getThreadMXBean();
+        Map<String, Object> threadAttrs = new HashMap<>();
+        safeStore("AllThreadIds", threadAttrs, threadBean::getAllThreadIds);
+        safeStore("CurrentThreadCpuTime", threadAttrs, threadBean::getCurrentThreadCpuTime);
+        safeStore("CurrentThreadUserTime", threadAttrs, threadBean::getCurrentThreadUserTime);
+        safeStore("DaemonThreadCount", threadAttrs, threadBean::getDaemonThreadCount);
+        safeStore("PeakThreadCount", threadAttrs, threadBean::getPeakThreadCount);
+        safeStore("ThreadCount", threadAttrs, threadBean::getThreadCount);
+        safeStore("TotalStartedThreadCount", threadAttrs, threadBean::getTotalStartedThreadCount);
+        safeStore(
+                "CurrentThreadCpuTimeSupported",
+                threadAttrs,
+                threadBean::isCurrentThreadCpuTimeSupported);
+        safeStore(
+                "ObjectMonitorUsageSupported",
+                threadAttrs,
+                threadBean::isObjectMonitorUsageSupported);
+        safeStore(
+                "SynchronizerUsageSupported",
+                threadAttrs,
+                threadBean::isSynchronizerUsageSupported);
+        safeStore(
+                "ThreadContentionMonitoringEnabled",
+                threadAttrs,
+                threadBean::isThreadContentionMonitoringEnabled);
+        safeStore(
+                "ThreadContentionMonitoringSupported",
+                threadAttrs,
+                threadBean::isThreadContentionMonitoringSupported);
+        safeStore("ThreadCpuTimeEnabled", threadAttrs, threadBean::isThreadCpuTimeEnabled);
+        safeStore("ThreadCpuTimeSupported", threadAttrs, threadBean::isThreadCpuTimeSupported);
+        ThreadMetrics threads = new ThreadMetrics(threadAttrs);
+
+        OperatingSystemMXBean osBean = ManagementFactory.getOperatingSystemMXBean();
+        Map<String, Object> osAttrs = new HashMap<>();
+        safeStore("Arch", osAttrs, osBean::getArch);
+        safeStore("AvailableProcessors", osAttrs, osBean::getAvailableProcessors);
+        safeStore("Name", osAttrs, osBean::getName);
+        safeStore("SystemLoadAverage", osAttrs, osBean::getSystemLoadAverage);
+        safeStore("Version", osAttrs, osBean::getVersion);
+        if (osBean instanceof UnixOperatingSystemMXBean) {
+            UnixOperatingSystemMXBean unix = (UnixOperatingSystemMXBean) osBean;
+            safeStore("CommittedVirtualMemorySize", osAttrs, unix::getCommittedVirtualMemorySize);
+            safeStore("FreePhysicalMemorySize", osAttrs, unix::getFreePhysicalMemorySize);
+            safeStore("FreeSwapSpaceSize", osAttrs, unix::getFreeSwapSpaceSize);
+            safeStore("ProcessCpuLoad", osAttrs, unix::getProcessCpuLoad);
+            safeStore("ProcessCpuTime", osAttrs, unix::getProcessCpuTime);
+            safeStore("SystemCpuLoad", osAttrs, unix::getSystemCpuLoad);
+            safeStore("TotalPhysicalMemorySize", osAttrs, unix::getTotalPhysicalMemorySize);
+            safeStore("TotalSwapSpaceSize", osAttrs, unix::getTotalSwapSpaceSize);
+        }
+        OperatingSystemMetrics os = new OperatingSystemMetrics(osAttrs);
+
+        String jvmId = null;
+        try (ByteArrayOutputStream baos = new ByteArrayOutputStream(512);
+                DataOutputStream dos = new DataOutputStream(baos)) {
+            dos.writeUTF(runtime.getClassPath());
+            dos.writeUTF(runtime.getName());
+            dos.writeUTF(Arrays.toString(runtime.getInputArguments()));
+            dos.writeUTF(runtime.getLibraryPath());
+            dos.writeUTF(runtime.getVmVendor());
+            dos.writeUTF(runtime.getVmVersion());
+            dos.writeLong(runtime.getStartTime());
+            byte[] hash = DigestUtils.sha256(baos.toByteArray());
+            jvmId = new String(Base64.getUrlEncoder().encode(hash), StandardCharsets.UTF_8).trim();
+        } catch (IOException e) {
+            log.error("Could not compute own jvmId!", e);
+        }
+
+        return new MBeanMetrics(runtime, memory, threads, os, jvmId);
+    }
+
+    private <T> void safeStore(String key, Map<String, Object> map, Callable<T> fn) {
+        try {
+            map.put(key, fn.call());
+        } catch (Exception e) {
+            log.warn("Call failed", e);
+        }
+    }
+}

--- a/src/main/java/io/cryostat/agent/remote/RemoteContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RemoteContext.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.agent.remote;
+
+import com.sun.net.httpserver.HttpHandler;
+
+public interface RemoteContext extends HttpHandler {
+    String path();
+}

--- a/src/main/java/io/cryostat/agent/remote/RemoteModule.java
+++ b/src/main/java/io/cryostat/agent/remote/RemoteModule.java
@@ -46,5 +46,5 @@ public abstract class RemoteModule {
 
     @Binds
     @IntoSet
-    abstract RemoteContext bindMbeanContext(MBeanContext ctx);
+    abstract RemoteContext bindMBeanContext(MBeanContext ctx);
 }

--- a/src/main/java/io/cryostat/agent/remote/RemoteModule.java
+++ b/src/main/java/io/cryostat/agent/remote/RemoteModule.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.agent.remote;
+
+import dagger.Binds;
+import dagger.Module;
+import dagger.multibindings.IntoSet;
+
+@Module
+public abstract class RemoteModule {
+
+    @Binds
+    @IntoSet
+    abstract RemoteContext bindMbeanContext(MBeanContext ctx);
+}


### PR DESCRIPTION
Fixes #79
See https://github.com/cryostatio/cryostat/pull/1415

This does some refactoring, and then adds a capability for remote clients (the Cryostat server most likely) to retrieve select MBean metrics data over the HTTP API. This requires the same authentication as the discovery plugin flow.