### PR TITLE
feat(api): remote readonly recordings access

### DIFF
--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright The Cryostat Authors
+ *
+ * The Universal Permissive License (UPL), Version 1.0
+ *
+ * Subject to the condition set forth below, permission is hereby granted to any
+ * person obtaining a copy of this software, associated documentation and/or data
+ * (collectively the "Software"), free of charge and under any and all copyright
+ * rights in the Software, and any and all patent rights owned or freely
+ * licensable by each licensor hereunder covering either (i) the unmodified
+ * Software as contributed to or provided by such licensor, or (ii) the Larger
+ * Works (as defined below), to deal in both
+ *
+ * (a) the Software, and
+ * (b) any piece of software and/or hardware listed in the lrgrwrks.txt file if
+ * one is included with the Software (each a "Larger Work" to which the Software
+ * is contributed by such licensors),
+ *
+ * without restriction, including without limitation the rights to copy, create
+ * derivative works of, display, perform, and distribute the Software and make,
+ * use, sell, offer for sale, import, export, have made, and have sold the
+ * Software and the Larger Work(s), and to sublicense the foregoing rights on
+ * either these or other terms.
+ *
+ * This license is subject to the following condition:
+ * The above copyright notice and either this complete permission notice or at
+ * a minimum a reference to the UPL must be included in all copies or
+ * substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+package io.cryostat.agent.remote;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import javax.inject.Inject;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sun.net.httpserver.HttpExchange;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import jdk.jfr.FlightRecorder;
+import jdk.jfr.Recording;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class RecordingsContext implements RemoteContext {
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
+    private final ObjectMapper mapper;
+
+    @Inject
+    RecordingsContext(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Override
+    public String path() {
+        return "/recordings";
+    }
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String mtd = exchange.getRequestMethod();
+        switch (mtd) {
+            case "GET":
+                try {
+                    List<RecordingInfo> recordings = getRecordings();
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                    try (OutputStream response = exchange.getResponseBody()) {
+                        mapper.writeValue(response, recordings);
+                    }
+                } catch (Exception e) {
+                    log.error("recordings serialization failure", e);
+                } finally {
+                    exchange.close();
+                }
+                break;
+            default:
+                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
+                exchange.close();
+                break;
+        }
+    }
+
+    private List<RecordingInfo> getRecordings() {
+        return FlightRecorder.getFlightRecorder().getRecordings().stream()
+                .map(RecordingInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    @SuppressFBWarnings(value = "URF_UNREAD_FIELD")
+    private static class RecordingInfo {
+
+        public final long id;
+        public final String name;
+        public final String state;
+        public final Map<String, String> options;
+        public final long startTime;
+        public final long duration;
+        public final boolean isContinuous;
+        public final boolean toDisk;
+        public final long maxSize;
+        public final long maxAge;
+
+        RecordingInfo(Recording rec) {
+            this.id = rec.getId();
+            this.name = rec.getName();
+            this.state = rec.getState().name();
+            this.options = rec.getSettings();
+            this.startTime = rec.getStartTime().toEpochMilli();
+            this.isContinuous = rec.getDuration() == null;
+            this.duration = this.isContinuous ? 0 : rec.getDuration().toMillis();
+            this.toDisk = rec.isToDisk();
+            this.maxSize = rec.getMaxSize();
+            this.maxAge = rec.getMaxAge().toMillis();
+        }
+    }
+}

--- a/src/main/java/io/cryostat/agent/remote/RemoteModule.java
+++ b/src/main/java/io/cryostat/agent/remote/RemoteModule.java
@@ -55,4 +55,8 @@ public abstract class RemoteModule {
     @Binds
     @IntoSet
     abstract RemoteContext bindEventTemplatesContext(EventTemplatesContext ctx);
+
+    @Binds
+    @IntoSet
+    abstract RemoteContext bindRecordingsContext(RecordingsContext ctx);
 }


### PR DESCRIPTION
See #78 and #80

This adds a `/recordings` API endpoint that exposes readonly information about the recordings present in the JVM.
