### PR TITLE
fix(periodic): config for maxage/maxsize to prevent recording upload timeouts due to large filesize

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.harvester.upload.timeout-ms` [`long`]: the duration in milliseconds to wait for HTTP upload requests to the Cryostat server to complete and respond. Default `30000`.
 - [ ] `cryostat.agent.harvester.exit.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to recording data uploaded to the Cryostat server when the JVM this Agent instance is attached to exits. This ensures that tail-end data is captured between the last periodic push and the application exit. Exit uploads only occur when the application receives `SIGINT`/`SIGTERM` from the operating system or container platform.
 - [ ] `cryostat.agent.harvester.exit.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to exit uploads as described above.
-- [ ] `cryostat.agent.harvester.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which is interpreted as 1.5x the harvester period (`cryostat.agent.harvester.-period-ms`).
+- [ ] `cryostat.agent.harvester.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which is interpreted as 1.5x the harvester period (`cryostat.agent.harvester.period-ms`).
 - [ ] `cryostat.agent.harvester.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which means `unlimited`.
 
 These properties can be set by JVM system properties or by environment variables. For example, the property

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.harvester.upload.timeout-ms` [`long`]: the duration in milliseconds to wait for HTTP upload requests to the Cryostat server to complete and respond. Default `30000`.
 - [ ] `cryostat.agent.harvester.exit.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to recording data uploaded to the Cryostat server when the JVM this Agent instance is attached to exits. This ensures that tail-end data is captured between the last periodic push and the application exit. Exit uploads only occur when the application receives `SIGINT`/`SIGTERM` from the operating system or container platform.
 - [ ] `cryostat.agent.harvester.exit.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to exit uploads as described above.
+- [ ] `cryostat.agent.harvester.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which is interpreted as 1.5x the harvester period (`cryostat.agent.harvester.-period-ms`).
+- [ ] `cryostat.agent.harvester.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which means `unlimited`.
 
 These properties can be set by JVM system properties or by environment variables. For example, the property
 `cryostat.agent.baseuri` can be set using `-Dcryostat.agent.baseuri=https://mycryostat.example.com:1234/` or

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -100,6 +100,10 @@ public abstract class ConfigModule {
             "cryostat.agent.harvester.exit.max-age-ms";
     public static final String CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B =
             "cryostat.agent.harvester.exit.max-size-b";
+    public static final String CRYOSTAT_AGENT_HARVESTER_MAX_AGE_MS =
+            "cryostat.agent.harvester.max-age-ms";
+    public static final String CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B =
+            "cryostat.agent.harvester.max-size-b";
 
     @Provides
     @Singleton
@@ -264,15 +268,29 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_AGE_MS)
-    public static long provideCryostatAgentHarvesterMaxAge(SmallRyeConfig config) {
+    public static long provideCryostatAgentHarvesterExitMaxAge(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_AGE_MS, long.class);
     }
 
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B)
-    public static long provideCryostatAgentHarvesterMaxSize(SmallRyeConfig config) {
+    public static long provideCryostatAgentHarvesterExitMaxSize(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B, long.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_HARVESTER_MAX_AGE_MS)
+    public static long provideCryostatAgentHarvesterMaxAge(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_HARVESTER_MAX_AGE_MS, long.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B)
+    public static long provideCryostatAgentHarvesterMaxSize(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B, long.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/Harvester.java
+++ b/src/main/java/io/cryostat/agent/Harvester.java
@@ -161,6 +161,20 @@ class Harvester implements FlightRecorderListener {
                                     exitSettings.maxSize,
                                     FileUtils.byteCountToDisplaySize(exitSettings.maxSize));
                         }
+                        if (periodicSettings.maxAge > 0) {
+                            log.info(
+                                    "Periodic uploads will contain approximately the most recent"
+                                            + " {}ms ({}) of data",
+                                    periodicSettings.maxAge,
+                                    Duration.ofMillis(periodicSettings.maxAge));
+                        }
+                        if (periodicSettings.maxSize > 0) {
+                            log.info(
+                                    "On-stop uploads will contain approximately the most recent {}"
+                                            + " bytes ({}) of data",
+                                    periodicSettings.maxSize,
+                                    FileUtils.byteCountToDisplaySize(periodicSettings.maxSize));
+                        }
                     } catch (SecurityException | IllegalStateException e) {
                         log.error("Harvester could not start", e);
                         return;

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -234,7 +234,7 @@ public abstract class MainModule {
     @Provides
     @Singleton
     public static Harvester provideHarvester(
-            ScheduledExecutorService executor,
+            ScheduledExecutorService workerPool,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_PERIOD_MS) long period,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_TEMPLATE) String template,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_MAX_FILES) int maxFiles,
@@ -251,7 +251,14 @@ public abstract class MainModule {
         periodicSettings.maxAge = maxAge > 0 ? maxAge : (long) (period * 1.5);
         periodicSettings.maxSize = maxSize;
         return new Harvester(
-                executor,
+                Executors.newSingleThreadScheduledExecutor(
+                        r -> {
+                            Thread t = new Thread(r);
+                            t.setName("cryostat-agent-harvester");
+                            t.setDaemon(true);
+                            return t;
+                        }),
+                workerPool,
                 period,
                 template,
                 maxFiles,

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -238,14 +238,27 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_PERIOD_MS) long period,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_TEMPLATE) String template,
             @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_MAX_FILES) int maxFiles,
-            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_AGE_MS) long maxAge,
-            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B) long maxSize,
+            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_AGE_MS) long exitMaxAge,
+            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_EXIT_MAX_SIZE_B) long exitMaxSize,
+            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_MAX_AGE_MS) long maxAge,
+            @Named(ConfigModule.CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B) long maxSize,
             CryostatClient client,
             Registration registration) {
-        RecordingSettings settings = new RecordingSettings();
-        settings.maxAge = maxAge;
-        settings.maxSize = maxSize;
-        return new Harvester(executor, period, template, maxFiles, settings, client, registration);
+        RecordingSettings exitSettings = new RecordingSettings();
+        exitSettings.maxAge = exitMaxAge;
+        exitSettings.maxSize = exitMaxSize;
+        RecordingSettings periodicSettings = new RecordingSettings();
+        periodicSettings.maxAge = maxAge > 0 ? maxAge : (long) (period * 1.5);
+        periodicSettings.maxSize = maxSize;
+        return new Harvester(
+                executor,
+                period,
+                template,
+                maxFiles,
+                exitSettings,
+                periodicSettings,
+                client,
+                registration);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -154,6 +154,7 @@ class Registration {
                         case UNREGISTERED:
                             if (this.registrationCheckTask != null) {
                                 this.registrationCheckTask.cancel(true);
+                                this.registrationCheckTask = null;
                             }
                             executor.submit(
                                     () -> {

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -24,3 +24,5 @@ cryostat.agent.harvester.max-files=2147483647
 cryostat.agent.harvester.upload.timeout-ms=30000
 cryostat.agent.harvester.exit.max-age-ms=0
 cryostat.agent.harvester.exit.max-size-b=0
+cryostat.agent.harvester.max-age-ms=0
+cryostat.agent.harvester.max-size-b=0


### PR DESCRIPTION
- add configs for periodic maxage and maxsize
- null out field on state transition
- split between dedicated thread and worker pool

Fixes #95
Depends on #99

Adds two new config parameters for the maxage/maxsize JFR properties. These two properties could already be controlled previously for recordings that are uploaded when the host JVM is exiting, but periodically pushed recordings would always push the entire available JFR repository contents. It's likely that this results in overlapping recording chunks being pushed to the server frequently, wasting network bandwidth and storage capacity. The new config parameters can be tuned to minimize this waste. The maxsize is not applied by default, but the maxage is, and the default data age is taken as 1.5x the harvester period. This will result in some overlap of recording chunks on each push, but probably much less than previously for common harvester periods and JFR repository sizes.

Also included are some fixes to ensure that one thread is responsible for managing the harvester and the state that it controls, and to ensure that the harvester does not get into a bad spinning state that I've seen when uploads fail. I have also seen uploads fail when the server sends the registration refresh POST signal, which would cause the spinning behaviour. In this PR single uploads that overlap(?) with handling the registration signal may still fail, but they are handled gracefully and the periodic push resumes as normal on the next scheduled attempt.

----

#### "Spinning" fix testing

Use the following Cryostat `smoketest.sh`:

```diff
diff --git a/smoketest.sh b/smoketest.sh
index 4aebf722..e5622ad0 100755
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -159,7 +159,7 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --env CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX="true" \
-        --env CRYOSTAT_AGENT_HARVESTER_PERIOD_MS=60000 \
+        --env CRYOSTAT_AGENT_HARVESTER_PERIOD_MS=15000 \
         --env CRYOSTAT_AGENT_HARVESTER_MAX_FILES=10 \
         --rm -d quay.io/andrewazores/quarkus-test:latest
```

`CRYOSTAT_DISCOVERY_PING_PERIOD=30000 sh smoketest.sh`. This sets the discovery callback POST ping signal to occur every 30 seconds. Every 15 seconds the agent should try to push a harvested JFR file to the server. Before this PR, the agent will get into a bad "spinning" state quite easily whenever it needs to reregister itself after the POST signal. After the PR the same root failure can still be observed, but results in the agent simply trying again later and succeeding.

#### maxage/maxsize testing

TODO determine a quicker way. I have observed some issues with the agent trying to push very large files and timing out when leaving the standard `smoketest.sh` setup running for long periods of time, but I'm not sure exactly how long this takes or if there are other extenuating circumstances that also contribute to the problems I have seen.