### PR TITLE
fix(credentials): store credentials with non-conflicting matchExpression

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-agent</artifactId>
-<version>0.3.0-SNAPSHOT</version>
+<version>0.2.3</version>
 <packaging>jar</packaging>
 <name>cryostat-agent</name>
 <url>http://maven.apache.org</url>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 <modelVersion>4.0.0</modelVersion>
 <groupId>io.cryostat</groupId>
 <artifactId>cryostat-agent</artifactId>
-<version>0.2.3</version>
+<version>0.3.0-SNAPSHOT</version>
 <packaging>jar</packaging>
 <name>cryostat-agent</name>
 <url>http://maven.apache.org</url>

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -113,10 +113,18 @@ public abstract class MainModule {
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
+            @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             Lazy<Registration> registration,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_RETRY_MS) int registrationRetryMs) {
         return new WebServer(
-                remoteContexts, cryostat, executor, host, port, registration, registrationRetryMs);
+                remoteContexts,
+                cryostat,
+                executor,
+                host,
+                port,
+                callback,
+                registration,
+                registrationRetryMs);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -39,6 +39,7 @@ package io.cryostat.agent;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
@@ -77,6 +78,7 @@ class WebServer {
     private final String host;
     private final int port;
     private final Credentials credentials;
+    private final URI callback;
     private final Lazy<Registration> registration;
     private final int registrationRetryMs;
     private HttpServer http;
@@ -92,6 +94,7 @@ class WebServer {
             ScheduledExecutorService executor,
             String host,
             int port,
+            URI callback,
             Lazy<Registration> registration,
             int registrationRetryMs) {
         this.remoteContexts = remoteContexts;
@@ -100,6 +103,7 @@ class WebServer {
         this.host = host;
         this.port = port;
         this.credentials = new Credentials();
+        this.callback = callback;
         this.registration = registration;
         this.registrationRetryMs = registrationRetryMs;
 
@@ -145,7 +149,7 @@ class WebServer {
             this.credentials.regenerate();
             return this.cryostat
                     .get()
-                    .submitCredentialsIfRequired(this.credentialId, this.credentials)
+                    .submitCredentialsIfRequired(this.credentialId, this.credentials, this.callback)
                     .handle(
                             (v, t) -> {
                                 if (t != null) {


### PR DESCRIPTION
Fixes #133

This simply changes the matchExpression that the Agent uses when it stores credentials in the Cryostat server's encrypted keyring.

Previously the matchExpression used would be set to match the target's JVM ID. As outlined in the original issue, this would cause problems for target applications with JMX authentication enabled, since the credentials stored by the Agent would match the same target, but are the wrong credentials for that connection.

It does not actually matter what the matchExpression of these stored credentials is because there is a custom subprotocol in use by the Agent and the Cryostat server, so the Cryostat server will always use the correct stored credentials given the correct ID for the Agent it is trying to connect to over HTTP. The matchExpression is simply used in this case to provide a meaningful link between the stored credential and the agent instance so that the user can tell which credentials are used for which connections.

The new matchExpression matches on the specific callback URL for the Agent instance. This should uniquely identify the Agent instance for the user, and also prevents the credential from being incorrectly picked up and used for any JMX connections that Cryostat initiates.

`quay.io/andrewazores/vertx-fib-demo:0.12.3` has been updated to use this modified agent, so its behaviour can be easily observed by updating the `smoketest.sh` script to update that image version. No other changes should be required.