### PR TITLE
ci(secrets): allow ci to use gh package secrets

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,7 +23,8 @@ jobs:
       run: exit 1
     - uses: actions/checkout@v2
       with:
-        repository: cryostatio/cryostat-core
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+        ref: ${{ github.event.pull_request.head.ref }}
         submodules: true
     - uses: actions/setup-java@v2
       with:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,13 +15,27 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
-
+  get-pom-properties:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Fail if safe-to-test label NOT applied
+      if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
+      run: exit 1
+    - id: query-pom
+      name: Get properties from POM
+      run: |
+        CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
+        echo "core-version=v$CORE_VERSION" >> $GITHUB_OUTPUT
+    outputs:
+      core-version: ${{ steps.query-pom.outputs.core-version }}
   build:
     runs-on: ubuntu-latest
+    needs: [get-pom-properties]
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        repository: cryostatio/cryostat-core
+        ref: ${{ needs.get-pom-properties.outputs.core-version }}
     - uses: actions/setup-java@v2
       with:
         java-version: '11'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
       - v[0-9]+
       - v[0-9]+.[0-9]+
       - cryostat-v[0-9]+.[0-9]+
-  pull_request:
+  pull_request_target:
     branches:
       - main
       - v[0-9]+

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,27 +15,16 @@ on:
       - cryostat-v[0-9]+.[0-9]+
 
 jobs:
-  get-pom-properties:
+  build:
     runs-on: ubuntu-latest
     steps:
     - name: Fail if safe-to-test label NOT applied
       if: ${{ !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
       run: exit 1
-    - id: query-pom
-      name: Get properties from POM
-      run: |
-        CORE_VERSION="$(mvn help:evaluate -Dexpression=io.cryostat.core.version -q -DforceStdout)"
-        echo "core-version=v$CORE_VERSION" >> $GITHUB_OUTPUT
-    outputs:
-      core-version: ${{ steps.query-pom.outputs.core-version }}
-  build:
-    runs-on: ubuntu-latest
-    needs: [get-pom-properties]
-    steps:
     - uses: actions/checkout@v2
       with:
         repository: cryostatio/cryostat-core
-        ref: ${{ needs.get-pom-properties.outputs.core-version }}
+        submodules: true
     - uses: actions/setup-java@v2
       with:
         java-version: '11'


### PR DESCRIPTION
Fixes #126

Not sure if it works because my fork doesn't own a gh repo token that is authenticated for use for pulling a `-core` dependency - does the fix make sense?