### PR TITLE
ci(mergify): add mergify config for `safe-to-test` label

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -9,3 +9,11 @@ pull_request_rules:
           - cryostat-v2.3
         assignees:
           - "{{ author }}"
+
+  - name: auto label PRs from reviewers
+    conditions:
+      - author=@reviewers
+    actions:
+      label:
+        add:
+          - safe-to-test


### PR DESCRIPTION
Related #126 
Related #151

Forgot to put in the mergify configuration to automatically add the label if the pr author is a member of @cryostatio/reviewers.