### PR TITLE
chore(ci): skip CI run on forks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,6 +27,7 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
     - name: Fail if PR and safe-to-test label NOT applied
       if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}


### PR DESCRIPTION
Related to #149
Related to #151 

Added a check to run CI job only upstream since forks will likely be missing secrets. This avoid CI fail notifications and reduce github use.