### PR TITLE
feat(api): enable dynamic JFR start

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 
 - [x] `cryostat.agent.baseuri` [`java.net.URI`]: the URL location of the Cryostat server backend that this agent advertises itself to.
 - [x] `cryostat.agent.callback` [`java.net.URI`]: a URL pointing back to this agent, ex. `"https://12.34.56.78:1234/"`. Cryostat will use this URL to perform health checks and request updates from the agent. This reflects the externally-visible IP address/hostname and port where this application and agent can be found.
+- [ ] `cryostat.agent.api.writes-enabled` [`boolean`]: Control whether the agent accepts "write" or mutating operations on its HTTP API. Requests for remote operations such as dynamically starting Flight Recordings will be rejected unless this is set. Default `false`.
 - [ ] `cryostat.agent.instance-id` [`String`]: a unique ID for this agent instance. This will be used to uniquely identify the agent in the Cryostat discovery database, as well as to unambiguously match its encrypted stored credentials. The default is a random UUID string. It is not recommended to override this value.
 - [ ] `cryostat.agent.hostname` [`String`]: the hostname for this application instance. This will be used for the published JMX connection URL. If not provided then the default is to attempt to resolve the localhost hostname.
 - [ ] `cryostat.agent.realm` [`String`]: the Cryostat Discovery API "realm" that this agent belongs to. This should be unique per agent instance. The default is the value of `cryostat.agent.app.name`.

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -107,6 +107,9 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B =
             "cryostat.agent.harvester.max-size-b";
 
+    public static final String CRYOSTAT_AGENT_API_WRITES_ENABLED =
+            "cryostat.agent.api.writes-enabled";
+
     @Provides
     @Singleton
     public static SmallRyeConfig provideConfig() {

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -37,7 +37,9 @@
  */
 package io.cryostat.agent;
 
+import java.io.IOException;
 import java.net.URI;
+import java.nio.file.Path;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
@@ -61,6 +63,7 @@ import io.cryostat.core.net.JFRConnection;
 import io.cryostat.core.net.JFRConnectionToolkit;
 import io.cryostat.core.sys.Environment;
 import io.cryostat.core.sys.FileSystem;
+import io.cryostat.core.templates.LocalStorageTemplateService;
 import io.cryostat.core.tui.ClientWriter;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -85,6 +88,7 @@ public abstract class MainModule {
     // one for outbound HTTP requests, one for incoming HTTP requests, and one as a general worker
     private static final int NUM_WORKER_THREADS = 3;
     private static final String JVM_ID = "JVM_ID";
+    private static final String TEMPLATES_PATH = "TEMPLATES_PATH";
 
     @Provides
     @Singleton
@@ -282,19 +286,59 @@ public abstract class MainModule {
 
     @Provides
     @Singleton
-    @Named(JVM_ID)
-    public static String provideJvmId() {
+    public static FileSystem provideFileSystem() {
+        return new FileSystem();
+    }
+
+    @Provides
+    @Singleton
+    @Named(TEMPLATES_PATH)
+    public static Path provideTemplatesTmpPath(FileSystem fs) {
+        try {
+            return fs.createTempDirectory(null);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Provides
+    @Singleton
+    public static Environment provideEnvironment(@Named(TEMPLATES_PATH) Path templatesTmp) {
+        return new Environment() {
+            @Override
+            public String getEnv(String key) {
+                if (LocalStorageTemplateService.TEMPLATE_PATH.equals(key)) {
+                    return templatesTmp.toString();
+                }
+                return super.getEnv(key);
+            }
+        };
+    }
+
+    @Provides
+    @Singleton
+    public static ClientWriter provideClientWriter() {
         Logger log = LoggerFactory.getLogger(JFRConnectionToolkit.class);
-        JFRConnectionToolkit tk =
-                new JFRConnectionToolkit(
-                        new ClientWriter() {
-                            @Override
-                            public void print(String msg) {
-                                log.warn(msg);
-                            }
-                        },
-                        new FileSystem(),
-                        new Environment());
+        return new ClientWriter() {
+            @Override
+            public void print(String msg) {
+                log.info(msg);
+            }
+        };
+    }
+
+    @Provides
+    @Singleton
+    public static JFRConnectionToolkit provideJfrConnectionToolkit(
+            ClientWriter cw, FileSystem fs, Environment env) {
+        return new JFRConnectionToolkit(cw, fs, env);
+    }
+
+    @Provides
+    @Singleton
+    @Named(JVM_ID)
+    public static String provideJvmId(JFRConnectionToolkit tk) {
+        Logger log = LoggerFactory.getLogger(JFRConnection.class);
         try {
             try (JFRConnection connection = tk.connect(tk.createServiceURL("localhost", 0))) {
                 String id = connection.getJvmId();
@@ -304,5 +348,12 @@ public abstract class MainModule {
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
+    }
+
+    @Provides
+    @Singleton
+    public static LocalStorageTemplateService provideLocalStorageTemplateService(
+            FileSystem fs, Environment env) {
+        return new LocalStorageTemplateService(fs, env);
     }
 }

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -338,7 +338,7 @@ public abstract class MainModule {
     @Singleton
     @Named(JVM_ID)
     public static String provideJvmId(JFRConnectionToolkit tk) {
-        Logger log = LoggerFactory.getLogger(JFRConnection.class);
+        Logger log = LoggerFactory.getLogger(JFRConnectionToolkit.class);
         try {
             try (JFRConnection connection = tk.connect(tk.createServiceURL("localhost", 0))) {
                 String id = connection.getJvmId();

--- a/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
@@ -70,30 +70,32 @@ class EventTemplatesContext implements RemoteContext {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        String mtd = exchange.getRequestMethod();
-        switch (mtd) {
-            case "GET":
-                try {
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
-                    try (OutputStream response = exchange.getResponseBody()) {
-                        FlightRecorderMXBean bean =
-                                ManagementFactory.getPlatformMXBean(FlightRecorderMXBean.class);
-                        List<String> xmlTexts =
-                                bean.getConfigurations().stream()
-                                        .map(ConfigurationInfo::getContents)
-                                        .collect(Collectors.toList());
-                        mapper.writeValue(response, xmlTexts);
+        try {
+            String mtd = exchange.getRequestMethod();
+            switch (mtd) {
+                case "GET":
+                    try {
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                        try (OutputStream response = exchange.getResponseBody()) {
+                            FlightRecorderMXBean bean =
+                                    ManagementFactory.getPlatformMXBean(FlightRecorderMXBean.class);
+                            List<String> xmlTexts =
+                                    bean.getConfigurations().stream()
+                                            .map(ConfigurationInfo::getContents)
+                                            .collect(Collectors.toList());
+                            mapper.writeValue(response, xmlTexts);
+                        }
+                    } catch (Exception e) {
+                        log.error("events serialization failure", e);
                     }
-                } catch (Exception e) {
-                    log.error("events serialization failure", e);
-                } finally {
-                    exchange.close();
-                }
-                break;
-            default:
-                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
-                exchange.close();
-                break;
+                    break;
+                default:
+                    log.warn("Unknown request method {}", mtd);
+                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    break;
+            }
+        } finally {
+            exchange.close();
         }
     }
 }

--- a/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
@@ -76,14 +76,17 @@ class EventTypesContext implements RemoteContext {
             String mtd = exchange.getRequestMethod();
             switch (mtd) {
                 case "GET":
+                    List<EventInfo> events = new ArrayList<>();
                     try {
-                        List<EventInfo> events = getEventTypes();
-                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
-                        try (OutputStream response = exchange.getResponseBody()) {
-                            mapper.writeValue(response, events);
-                        }
+                        events.addAll(getEventTypes());
                     } catch (Exception e) {
                         log.error("events serialization failure", e);
+                        exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, 0);
+                        break;
+                    }
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                    try (OutputStream response = exchange.getResponseBody()) {
+                        mapper.writeValue(response, events);
                     }
                     break;
                 default:

--- a/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
@@ -72,25 +72,27 @@ class EventTypesContext implements RemoteContext {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        String mtd = exchange.getRequestMethod();
-        switch (mtd) {
-            case "GET":
-                try {
-                    List<EventInfo> events = getEventTypes();
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
-                    try (OutputStream response = exchange.getResponseBody()) {
-                        mapper.writeValue(response, events);
+        try {
+            String mtd = exchange.getRequestMethod();
+            switch (mtd) {
+                case "GET":
+                    try {
+                        List<EventInfo> events = getEventTypes();
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                        try (OutputStream response = exchange.getResponseBody()) {
+                            mapper.writeValue(response, events);
+                        }
+                    } catch (Exception e) {
+                        log.error("events serialization failure", e);
                     }
-                } catch (Exception e) {
-                    log.error("events serialization failure", e);
-                } finally {
-                    exchange.close();
-                }
-                break;
-            default:
-                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
-                exchange.close();
-                break;
+                    break;
+                default:
+                    log.warn("Unknown request method {}", mtd);
+                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    break;
+            }
+        } finally {
+            exchange.close();
         }
     }
 

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -86,25 +86,27 @@ class MBeanContext implements RemoteContext {
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        String mtd = exchange.getRequestMethod();
-        switch (mtd) {
-            case "GET":
-                try {
-                    MBeanMetrics metrics = getMBeanMetrics();
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
-                    try (OutputStream response = exchange.getResponseBody()) {
-                        mapper.writeValue(response, metrics);
+        try {
+            String mtd = exchange.getRequestMethod();
+            switch (mtd) {
+                case "GET":
+                    try {
+                        MBeanMetrics metrics = getMBeanMetrics();
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                        try (OutputStream response = exchange.getResponseBody()) {
+                            mapper.writeValue(response, metrics);
+                        }
+                    } catch (Exception e) {
+                        log.error("mbean serialization failure", e);
                     }
-                } catch (Exception e) {
-                    log.error("mbean serialization failure", e);
-                } finally {
-                    exchange.close();
-                }
-                break;
-            default:
-                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
-                exchange.close();
-                break;
+                    break;
+                default:
+                    log.warn("Unknown request method {}", mtd);
+                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    break;
+            }
+        } finally {
+            exchange.close();
         }
     }
 

--- a/src/main/java/io/cryostat/agent/remote/MutatingRemoteContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MutatingRemoteContext.java
@@ -37,12 +37,24 @@
  */
 package io.cryostat.agent.remote;
 
-import com.sun.net.httpserver.HttpHandler;
+import io.cryostat.agent.ConfigModule;
 
-public interface RemoteContext extends HttpHandler {
-    String path();
+import io.smallrye.config.SmallRyeConfig;
 
-    default boolean available() {
-        return true;
+public abstract class MutatingRemoteContext implements RemoteContext {
+
+    protected final SmallRyeConfig config;
+
+    protected MutatingRemoteContext(SmallRyeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public boolean available() {
+        return apiWritesEnabled(config);
+    }
+
+    public static boolean apiWritesEnabled(SmallRyeConfig config) {
+        return config.getValue(ConfigModule.CRYOSTAT_AGENT_API_WRITES_ENABLED, boolean.class);
     }
 }

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -106,7 +106,6 @@ class RecordingsContext implements RemoteContext {
         try {
             String mtd = exchange.getRequestMethod();
             if (!ensureMethodAccepted(exchange)) {
-                exchange.close();
                 return;
             }
             switch (mtd) {

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -126,7 +126,6 @@ class RecordingsContext implements RemoteContext {
                     try (InputStream body = exchange.getRequestBody()) {
                         StartRecordingRequest req =
                                 mapper.readValue(body, StartRecordingRequest.class);
-                        log.info(mapper.writeValueAsString(req));
                         if (!req.isValid()) {
                             exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
                             return;
@@ -152,7 +151,7 @@ class RecordingsContext implements RemoteContext {
 
                                             @Override
                                             public void println(Exception e) {
-                                                log.warn("", e);
+                                                log.warn("JFR MBean connection failure", e);
                                             }
                                         },
                                         fs,
@@ -202,9 +201,6 @@ class RecordingsContext implements RemoteContext {
                                                             .build(),
                                                     events));
                             exchange.sendResponseHeaders(HttpStatus.SC_CREATED, 0);
-                            log.info(
-                                    "Responding with new recording:\n{}",
-                                    mapper.writeValueAsString(recording));
                             try (OutputStream response = exchange.getResponseBody()) {
                                 mapper.writeValue(response, recording);
                             }

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -1,6 +1,8 @@
 cryostat.agent.app.name=cryostat-agent
 cryostat.agent.baseuri=
 
+cryostat.agent.api.writes-enabled=false
+
 cryostat.agent.webclient.ssl.trust-all=false
 cryostat.agent.webclient.ssl.verify-hostname=true
 cryostat.agent.webclient.connect.timeout-ms=1000


### PR DESCRIPTION
Fixes #163
Fixes #164
Depends on https://github.com/cryostatio/cryostat-core/pull/245

Not yet implemented: restarting already existing recordings, manual stop of running recordings, opening stream (download) recordings. This only enables the ability to remotely start a recording over HTTP.
