### PR TITLE
feat(api): enable dynamic JFR stop, delete

### DIFF
--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -163,7 +163,8 @@ class WebServer {
                 handler.handle(x);
             } catch (Exception e) {
                 log.error("Unhandled exception", e);
-                x.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, 0);
+                x.sendResponseHeaders(
+                        HttpStatus.SC_INTERNAL_SERVER_ERROR, RemoteContext.BODY_LENGTH_NONE);
                 x.close();
             }
         };
@@ -184,15 +185,18 @@ class WebServer {
                     case "POST":
                         synchronized (WebServer.this.credentials) {
                             executor.execute(registration.get()::tryRegister);
-                            exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                            exchange.sendResponseHeaders(
+                                    HttpStatus.SC_NO_CONTENT, RemoteContext.BODY_LENGTH_NONE);
                         }
                         break;
                     case "GET":
-                        exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                        exchange.sendResponseHeaders(
+                                HttpStatus.SC_NO_CONTENT, RemoteContext.BODY_LENGTH_NONE);
                         break;
                     default:
                         log.warn("Unknown request method {}", mtd);
-                        exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                        exchange.sendResponseHeaders(
+                                HttpStatus.SC_METHOD_NOT_ALLOWED, RemoteContext.BODY_LENGTH_NONE);
                         break;
                 }
             } finally {

--- a/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
@@ -53,7 +53,7 @@ class EventTemplatesContext implements RemoteContext {
             switch (mtd) {
                 case "GET":
                     try {
-                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
                         try (OutputStream response = exchange.getResponseBody()) {
                             FlightRecorderMXBean bean =
                                     ManagementFactory.getPlatformMXBean(FlightRecorderMXBean.class);
@@ -69,7 +69,8 @@ class EventTemplatesContext implements RemoteContext {
                     break;
                 default:
                     log.warn("Unknown request method {}", mtd);
-                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    exchange.sendResponseHeaders(
+                            HttpStatus.SC_METHOD_NOT_ALLOWED, BODY_LENGTH_NONE);
                     break;
             }
         } finally {

--- a/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTemplatesContext.java
@@ -43,7 +43,7 @@ class EventTemplatesContext implements RemoteContext {
 
     @Override
     public String path() {
-        return "/event-templates";
+        return "/event-templates/";
     }
 
     @Override

--- a/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
@@ -59,17 +59,19 @@ class EventTypesContext implements RemoteContext {
                         events.addAll(getEventTypes());
                     } catch (Exception e) {
                         log.error("events serialization failure", e);
-                        exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, 0);
+                        exchange.sendResponseHeaders(
+                                HttpStatus.SC_INTERNAL_SERVER_ERROR, BODY_LENGTH_NONE);
                         break;
                     }
-                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                    exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
                     try (OutputStream response = exchange.getResponseBody()) {
                         mapper.writeValue(response, events);
                     }
                     break;
                 default:
                     log.warn("Unknown request method {}", mtd);
-                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    exchange.sendResponseHeaders(
+                            HttpStatus.SC_METHOD_NOT_ALLOWED, BODY_LENGTH_NONE);
                     break;
             }
         } finally {

--- a/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
+++ b/src/main/java/io/cryostat/agent/remote/EventTypesContext.java
@@ -45,7 +45,7 @@ class EventTypesContext implements RemoteContext {
 
     @Override
     public String path() {
-        return "/event-types";
+        return "/event-types/";
     }
 
     @Override

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -70,8 +70,7 @@ class MBeanContext implements RemoteContext {
                 case "GET":
                     try {
                         MBeanMetrics metrics = getMBeanMetrics();
-                        exchange.sendResponseHeaders(
-                                HttpStatus.SC_OK, RemoteContext.BODY_LENGTH_UNKNOWN);
+                        exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
                         try (OutputStream response = exchange.getResponseBody()) {
                             mapper.writeValue(response, metrics);
                         }
@@ -82,7 +81,7 @@ class MBeanContext implements RemoteContext {
                 default:
                     log.warn("Unknown request method {}", mtd);
                     exchange.sendResponseHeaders(
-                            HttpStatus.SC_METHOD_NOT_ALLOWED, RemoteContext.BODY_LENGTH_NONE);
+                            HttpStatus.SC_METHOD_NOT_ALLOWED, BODY_LENGTH_NONE);
                     break;
             }
         } finally {

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -70,7 +70,8 @@ class MBeanContext implements RemoteContext {
                 case "GET":
                     try {
                         MBeanMetrics metrics = getMBeanMetrics();
-                        exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                        exchange.sendResponseHeaders(
+                                HttpStatus.SC_OK, RemoteContext.BODY_LENGTH_UNKNOWN);
                         try (OutputStream response = exchange.getResponseBody()) {
                             mapper.writeValue(response, metrics);
                         }
@@ -80,7 +81,8 @@ class MBeanContext implements RemoteContext {
                     break;
                 default:
                     log.warn("Unknown request method {}", mtd);
-                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    exchange.sendResponseHeaders(
+                            HttpStatus.SC_METHOD_NOT_ALLOWED, RemoteContext.BODY_LENGTH_NONE);
                     break;
             }
         } finally {

--- a/src/main/java/io/cryostat/agent/remote/MBeanContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MBeanContext.java
@@ -59,7 +59,7 @@ class MBeanContext implements RemoteContext {
 
     @Override
     public String path() {
-        return "/mbean-metrics";
+        return "/mbean-metrics/";
     }
 
     @Override

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -220,9 +220,9 @@ class RecordingsContext implements RemoteContext {
     }
 
     private boolean ensureMethodAccepted(HttpExchange exchange) throws IOException {
-        Set<String> blocked = Set.of("POST");
+        Set<String> alwaysAllowed = Set.of("GET");
         String mtd = exchange.getRequestMethod();
-        boolean restricted = blocked.contains(mtd);
+        boolean restricted = !alwaysAllowed.contains(mtd);
         if (!restricted) {
             return true;
         }

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -116,11 +116,12 @@ class RecordingsContext implements RemoteContext {
                     }
                 case "DELETE":
                     id = extractId(exchange);
-                    if (id < 0) {
+                    if (id >= 0) {
                         handleDelete(exchange, id);
                     } else {
                         exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
                     }
+                    break;
                 default:
                     log.warn("Unknown request method {}", mtd);
                     exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -109,11 +109,12 @@ class RecordingsContext implements RemoteContext {
                     break;
                 case "PATCH":
                     id = extractId(exchange);
-                    if (id < 0) {
+                    if (id >= 0) {
                         handleStop(exchange, id);
                     } else {
                         exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
                     }
+                    break;
                 case "DELETE":
                     id = extractId(exchange);
                     if (id >= 0) {

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -101,7 +101,8 @@ class RecordingsContext implements RemoteContext {
                     if (id == Integer.MIN_VALUE) {
                         handleGetList(exchange);
                     } else {
-                        exchange.sendResponseHeaders(HttpStatus.SC_NOT_IMPLEMENTED, -1);
+                        exchange.sendResponseHeaders(
+                                HttpStatus.SC_NOT_IMPLEMENTED, BODY_LENGTH_NONE);
                     }
                     break;
                 case "POST":
@@ -112,7 +113,7 @@ class RecordingsContext implements RemoteContext {
                     if (id >= 0) {
                         handleStop(exchange, id);
                     } else {
-                        exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
+                        exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, BODY_LENGTH_NONE);
                     }
                     break;
                 case "DELETE":
@@ -120,12 +121,13 @@ class RecordingsContext implements RemoteContext {
                     if (id >= 0) {
                         handleDelete(exchange, id);
                     } else {
-                        exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
+                        exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, BODY_LENGTH_NONE);
                     }
                     break;
                 default:
                     log.warn("Unknown request method {}", mtd);
-                    exchange.sendResponseHeaders(HttpStatus.SC_METHOD_NOT_ALLOWED, -1);
+                    exchange.sendResponseHeaders(
+                            HttpStatus.SC_METHOD_NOT_ALLOWED, BODY_LENGTH_NONE);
                     break;
             }
         } finally {
@@ -144,7 +146,7 @@ class RecordingsContext implements RemoteContext {
     private void handleGetList(HttpExchange exchange) {
         try (OutputStream response = exchange.getResponseBody()) {
             List<SerializableRecordingDescriptor> recordings = getRecordings();
-            exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+            exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
             mapper.writeValue(response, recordings);
         } catch (Exception e) {
             log.error("recordings serialization failure", e);
@@ -155,11 +157,11 @@ class RecordingsContext implements RemoteContext {
         try (InputStream body = exchange.getRequestBody()) {
             StartRecordingRequest req = mapper.readValue(body, StartRecordingRequest.class);
             if (!req.isValid()) {
-                exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, -1);
+                exchange.sendResponseHeaders(HttpStatus.SC_BAD_REQUEST, BODY_LENGTH_NONE);
                 return;
             }
             SerializableRecordingDescriptor recording = startRecording(req);
-            exchange.sendResponseHeaders(HttpStatus.SC_CREATED, 0);
+            exchange.sendResponseHeaders(HttpStatus.SC_CREATED, BODY_LENGTH_UNKNOWN);
             try (OutputStream response = exchange.getResponseBody()) {
                 mapper.writeValue(response, recording);
             }
@@ -171,7 +173,7 @@ class RecordingsContext implements RemoteContext {
                 | InvalidXmlException
                 | IOException e) {
             log.error("Failed to start recording", e);
-            exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, -1);
+            exchange.sendResponseHeaders(HttpStatus.SC_INTERNAL_SERVER_ERROR, BODY_LENGTH_NONE);
         }
     }
 
@@ -213,7 +215,7 @@ class RecordingsContext implements RemoteContext {
 
     private void sendHeader(HttpExchange exchange, int status) {
         try {
-            exchange.sendResponseHeaders(status, -1);
+            exchange.sendResponseHeaders(status, BODY_LENGTH_NONE);
         } catch (IOException e) {
             throw new IllegalStateException(e);
         }
@@ -228,7 +230,7 @@ class RecordingsContext implements RemoteContext {
         }
         boolean passed = restricted && MutatingRemoteContext.apiWritesEnabled(config);
         if (!passed) {
-            exchange.sendResponseHeaders(HttpStatus.SC_FORBIDDEN, -1);
+            exchange.sendResponseHeaders(HttpStatus.SC_FORBIDDEN, BODY_LENGTH_NONE);
         }
         return passed;
     }

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -95,7 +95,7 @@ class RecordingsContext implements RemoteContext {
             switch (mtd) {
                 case "GET":
                     int id = extractId(exchange);
-                    if (id < 0) {
+                    if (id == Integer.MIN_VALUE) {
                         handleGetList(exchange);
                     } else {
                         exchange.sendResponseHeaders(HttpStatus.SC_NOT_IMPLEMENTED, -1);

--- a/src/main/java/io/cryostat/agent/remote/RemoteContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RemoteContext.java
@@ -18,6 +18,10 @@ package io.cryostat.agent.remote;
 import com.sun.net.httpserver.HttpHandler;
 
 public interface RemoteContext extends HttpHandler {
+
+    public static final int BODY_LENGTH_NONE = -1;
+    public static final int BODY_LENGTH_UNKNOWN = 0;
+
     String path();
 
     default boolean available() {


### PR DESCRIPTION
See #165
Related to #124

Adds remote endpoint ability to HTTP request Agent to stop or delete JFR by ID.
