### PR TITLE
feat(api): implement GET /recordings/:id for streaming files

### DIFF
--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -164,16 +164,18 @@ class RecordingsContext implements RemoteContext {
                                     BufferedInputStream bis = new BufferedInputStream(stream);
                                     OutputStream response = exchange.getResponseBody()) {
                                 if (stream == null) {
-                                    exchange.sendResponseHeaders(HttpStatus.SC_NO_CONTENT, -1);
+                                    exchange.sendResponseHeaders(
+                                            HttpStatus.SC_NO_CONTENT, BODY_LENGTH_NONE);
                                 } else {
-                                    exchange.sendResponseHeaders(HttpStatus.SC_OK, 0);
+                                    exchange.sendResponseHeaders(
+                                            HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
                                     bis.transferTo(response);
                                 }
                             } catch (IOException ioe) {
                                 log.error("I/O error", ioe);
                                 try {
                                     exchange.sendResponseHeaders(
-                                            HttpStatus.SC_INTERNAL_SERVER_ERROR, -1);
+                                            HttpStatus.SC_INTERNAL_SERVER_ERROR, BODY_LENGTH_NONE);
                                 } catch (IOException ioe2) {
                                     log.error("Failed to write response", ioe2);
                                 }
@@ -183,7 +185,8 @@ class RecordingsContext implements RemoteContext {
                         },
                         () -> {
                             try {
-                                exchange.sendResponseHeaders(HttpStatus.SC_NOT_FOUND, -1);
+                                exchange.sendResponseHeaders(
+                                        HttpStatus.SC_NOT_FOUND, BODY_LENGTH_NONE);
                             } catch (IOException e) {
                                 log.error("Failed to write response", e);
                             }

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -94,7 +94,7 @@ class RecordingsContext implements RemoteContext {
             if (!ensureMethodAccepted(exchange)) {
                 return;
             }
-            int id = Integer.MIN_VALUE;
+            long id = Long.MIN_VALUE;
             switch (mtd) {
                 case "GET":
                     id = extractId(exchange);
@@ -135,12 +135,12 @@ class RecordingsContext implements RemoteContext {
         }
     }
 
-    private static int extractId(HttpExchange exchange) throws IOException {
+    private static long extractId(HttpExchange exchange) throws IOException {
         Matcher m = PATH_ID_PATTERN.matcher(exchange.getRequestURI().getPath());
         if (!m.find()) {
-            return Integer.MIN_VALUE;
+            return Long.MIN_VALUE;
         }
-        return Integer.parseInt(m.group(1));
+        return Long.parseLong(m.group(1));
     }
 
     private void handleGetList(HttpExchange exchange) {
@@ -177,7 +177,7 @@ class RecordingsContext implements RemoteContext {
         }
     }
 
-    private void handleStop(HttpExchange exchange, int id) throws IOException {
+    private void handleStop(HttpExchange exchange, long id) throws IOException {
         invokeOnRecording(
                 exchange,
                 id,
@@ -195,7 +195,7 @@ class RecordingsContext implements RemoteContext {
                 });
     }
 
-    private void handleDelete(HttpExchange exchange, int id) throws IOException {
+    private void handleDelete(HttpExchange exchange, long id) throws IOException {
         invokeOnRecording(
                 exchange,
                 id,


### PR DESCRIPTION
- use longs for IDs
- feat(api): implement GET /recordings/:id for streaming files

Based on #176
Fixes #178
