### PR TITLE
feat(discovery): dual HTTP+JMX registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,6 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.webserver.port` [`int`]: the internal port number for the embedded webserver to bind to. Default `9977`.
 - [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. Default `cryostat-agent`.
 - [ ] `cryostat.agent.app.jmx.port` [`int`]: the JMX RMI port that the application is listening on. The default is to attempt to determine this from the `com.sun.management.jmxremote.port` system property.
-- [ ] `cryostat.agent.registration.prefer-jmx` [`boolean`]: control whether the Agent prefers to publish itself as reachable via JMX or HTTP. If JMX is not enabled on the application JVM then the Agent will always publish itself using HTTP. Default `false`.
 - [ ] `cryostat.agent.registration.retry-ms` [`long`]: the duration in milliseconds between attempts to register with the Cryostat server. Default `5000`.
 - [ ] `cryostat.agent.exit.signals` [`[String]`]: a comma-separated list of signals that the agent should handle. When any of these signals is caught the agent initiates an orderly shutdown, deregistering from the Cryostat server and potentially uploading the latest harvested JFR data. Default `INT,TERM`.
 - [ ] `cryostat.agent.exit.deregistration.timeout-ms` [`long`]: the duration in milliseconds to wait for a response from the Cryostat server when attempting to deregister at shutdown time . Default `3s`.

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -58,8 +58,6 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_APP_NAME = "cryostat.agent.app.name";
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
     public static final String CRYOSTAT_AGENT_APP_JMX_PORT = "cryostat.agent.app.jmx.port";
-    public static final String CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX =
-            "cryostat.agent.registration.prefer-jmx";
     public static final String CRYOSTAT_AGENT_REGISTRATION_RETRY_MS =
             "cryostat.agent.registration.retry-ms";
     public static final String CRYOSTAT_AGENT_REGISTRATION_CHECK_MS =
@@ -204,14 +202,6 @@ public abstract class ConfigModule {
                 .orElse(
                         Integer.valueOf(
                                 System.getProperty("com.sun.management.jmxremote.port", "-1")));
-    }
-
-    @Provides
-    @Singleton
-    @Named(CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX)
-    public static boolean provideCryostatAgentRegistrationPreferJmx(SmallRyeConfig config) {
-        return config.getOptionalValue(CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX, boolean.class)
-                .orElse(false);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -26,10 +26,10 @@ import java.nio.file.Path;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
@@ -335,7 +335,8 @@ public class CryostatClient {
                 .thenApply(res -> null);
     }
 
-    public CompletableFuture<Void> update(PluginInfo pluginInfo, Set<DiscoveryNode> subtree) {
+    public CompletableFuture<Void> update(
+            PluginInfo pluginInfo, Collection<DiscoveryNode> subtree) {
         try {
             HttpPost req =
                     new HttpPost(

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -200,7 +200,6 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
             @Named(ConfigModule.CRYOSTAT_AGENT_HOSTNAME) String hostname,
-            @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_PREFER_JMX) boolean preferJmx,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_JMX_PORT) int jmxPort,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_RETRY_MS) int registrationRetryMs,
             @Named(ConfigModule.CRYOSTAT_AGENT_REGISTRATION_CHECK_MS) int registrationCheckMs) {
@@ -229,7 +228,6 @@ public abstract class MainModule {
                 appName,
                 realm,
                 hostname,
-                preferJmx,
                 jmxPort,
                 registrationRetryMs,
                 registrationCheckMs);

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -21,9 +21,8 @@ import java.net.UnknownHostException;
 import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.ArrayList;
+import java.util.Collection;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
@@ -237,7 +236,7 @@ class Registration {
             log.warn("update attempted before initialized");
             return;
         }
-        List<DiscoveryNode> selfNodes;
+        Collection<DiscoveryNode> selfNodes;
         try {
             selfNodes = defineSelf();
         } catch (UnknownHostException | URISyntaxException e) {
@@ -267,8 +266,8 @@ class Registration {
         }
     }
 
-    private List<DiscoveryNode> defineSelf() throws UnknownHostException, URISyntaxException {
-        List<DiscoveryNode> discoveryNodes = new ArrayList<>();
+    private Set<DiscoveryNode> defineSelf() throws UnknownHostException, URISyntaxException {
+        Set<DiscoveryNode> discoveryNodes = new HashSet<>();
 
         long pid = ProcessHandle.current().pid();
         String javaMain = System.getProperty("sun.java.command", System.getenv("JAVA_MAIN_CLASS"));

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import io.cryostat.agent.model.DiscoveryNode;
 import io.cryostat.agent.model.PluginInfo;
@@ -245,7 +246,9 @@ class Registration {
         }
         log.info(
                 "publishing self as {}",
-                selfNodes.stream().map(n -> n.getTarget().getConnectUrl()).toList());
+                selfNodes.stream()
+                        .map(n -> n.getTarget().getConnectUrl())
+                        .collect(Collectors.toList()));
         Future<Void> f =
                 cryostat.update(pluginInfo, selfNodes)
                         .handle(

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -17,7 +17,6 @@ cryostat.agent.realm=
 cryostat.agent.exit.signals=INT,TERM
 cryostat.agent.registration.retry-ms=5000
 cryostat.agent.registration.check-ms=60000
-cryostat.agent.registration.prefer-jmx=false
 cryostat.agent.exit.deregistration.timeout-ms=3000
 
 cryostat.agent.harvester.period-ms=-1


### PR DESCRIPTION
Fixes #166

The Agent will always register as a discovery plugin and publish at least one JVM node describing itself as an Agent HTTP connection. If the Agent detects that JMX is also available on the target JVM then it will also publish a second JVM node describing itself with that JMX URL for connection.

![image](https://github.com/cryostatio/cryostat-agent/assets/3787464/f78dea80-64eb-4263-b1fa-496e0d2f2f41)
