### PR TITLE
feat(triggers): allow specification of triggers using SmallRye Config properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,10 @@ on a set of constraints specified by the user.
 The general form of a smart trigger expression is as follows:
 
 ```
-[constraint1(&&/||)constraint2...constraintN]~recordingTemplate
+[constraint1(&&/||)constraint2...constraintN]~recordingTemplateNameOrLabel
 ```
+
+Either the filename or label XML tag of the `${templateName}.jfc` may be used to specify the event template to use. For example, the JDK distribution ships with a `default.jfc` file containing the top-level `<configuration label="Continuous">` element. This template may be specified in the Smart Trigger definition as any of `default.jfc`, `default`, or `Continuous`.
 
 An example for listening to CPU Usage and starting a recording using the Profiling template when it exceeds 0.2%:
 

--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ JAVA_OPTIONS="-javaagent:/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSIO
 or as a [configuration property](#configuration):
 
 ```
-CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS="[ThreadCount>0&&TargetDuration>duration(\"1m\")]~default.jfc"
+CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS="[ProcessCpuLoad>0.2&&TargetDuration>duration(\"1m\")]~default.jfc"
 
--Dcryostat.agent.smart-trigger.definitions="[ThreadCount>0&&TargetDuration>duration(\"1m\")]~default.jfc"
+-Dcryostat.agent.smart-trigger.definitions="[ProcessCpuLoad>0.2&&TargetDuration>duration(\"1m\")]~default.jfc"
 ```
 
-Multiple smart trigger definitions may be specified and separated by commas, for example:
+Multiple Smart Trigger definitions may be specified and separated by commas, for example:
 
 ```
 [ProcessCpuLoad>0.2]~profile,[ThreadCount>30]~Continuous

--- a/README.md
+++ b/README.md
@@ -62,10 +62,18 @@ Continuous template:
 [ThreadCount>20&&TargetDuration>duration("10s")]~Continuous
 ```
 
-These must be passed as an argument to the cryostat agent, for example:
+These may be passed as an argument to the Cryostat Agent, for example:
 
 ```
 JAVA_OPTIONS="-javaagent:/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=[ProcessCpuLoad>0.2]~profile
+```
+
+or as a [configuration property](#configuration):
+
+```
+CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS="[ThreadCount>0&&TargetDuration>duration(\"1m\")]~default.jfc"
+
+-Dcryostat.agent.smart-trigger.definitions="[ThreadCount>0&&TargetDuration>duration(\"1m\")]~default.jfc"
 ```
 
 Multiple smart trigger definitions may be specified and separated by commas, for example:
@@ -117,6 +125,7 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.harvester.exit.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to exit uploads as described above.
 - [ ] `cryostat.agent.harvester.max-age-ms` [`long`]: the JFR `maxage` setting, specified in milliseconds, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which is interpreted as 1.5x the harvester period (`cryostat.agent.harvester.period-ms`).
 - [ ] `cryostat.agent.harvester.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which means `unlimited`.
+- [ ] `cryostat.agent.smart-trigger.definitions` [`String[]`]: a comma-separated list of Smart Trigger definitions to load at startup. Defaults to the empty string: no Smart Triggers.
 - [ ] `cryostat.agent.smart-trigger.evaluation.period-ms` [`long`]: the length of time between Smart Trigger evaluations. Default `1000`.
 
 These properties can be set by JVM system properties or by environment variables. For example, the property

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -297,7 +297,8 @@ public abstract class ConfigModule {
     @Singleton
     @Named(CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS)
     public static List<String> provideCryostatSmartTriggerDefinitions(SmallRyeConfig config) {
-        return config.getValues(CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS, String.class);
+        return config.getOptionalValues(CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS, String.class)
+                .orElse(List.of());
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -83,6 +83,8 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_HARVESTER_MAX_SIZE_B =
             "cryostat.agent.harvester.max-size-b";
 
+    public static final String CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS =
+            "cryostat.agent.smart-trigger.definitions";
     public static final String CRYOSTAT_AGENT_SMART_TRIGGER_EVALUATION_PERIOD_MS =
             "cryostat.agent.smart-trigger.evaluation.period-ms";
 
@@ -289,6 +291,13 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_EXIT_DEREGISTRATION_TIMEOUT_MS)
     public static long provideCryostatAgentExitDeregistrationTimeoutMs(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_EXIT_DEREGISTRATION_TIMEOUT_MS, long.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS)
+    public static List<String> provideCryostatSmartTriggerDefinitions(SmallRyeConfig config) {
+        return config.getValues(CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS, String.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
@@ -17,6 +17,7 @@ package io.cryostat.agent.triggers;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
@@ -43,6 +44,7 @@ import org.slf4j.LoggerFactory;
 public class TriggerEvaluator {
 
     private final ScheduledExecutorService scheduler;
+    private final List<String> definitions;
     private final TriggerParser parser;
     private final FlightRecorderHelper flightRecorderHelper;
     private final Harvester harvester;
@@ -53,11 +55,13 @@ public class TriggerEvaluator {
 
     public TriggerEvaluator(
             ScheduledExecutorService scheduler,
+            List<String> definitions,
             TriggerParser parser,
             FlightRecorderHelper flightRecorderHelper,
             Harvester harvester,
             long evaluationPeriodMs) {
         this.scheduler = scheduler;
+        this.definitions = Collections.unmodifiableList(definitions);
         this.parser = parser;
         this.flightRecorderHelper = flightRecorderHelper;
         this.harvester = harvester;
@@ -67,6 +71,7 @@ public class TriggerEvaluator {
     public void start(String[] args) {
         this.stop();
         parser.parse(args).forEach(this::registerTrigger);
+        parser.parse(definitions.toArray(new String[0])).forEach(this::registerTrigger);
         this.start();
     }
 

--- a/src/main/java/io/cryostat/agent/triggers/TriggerModule.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerModule.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.agent.triggers;
 
+import java.util.List;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
@@ -50,11 +51,13 @@ public abstract class TriggerModule {
     @Singleton
     public static TriggerEvaluator provideTriggerEvaluatorFactory(
             @Named(TRIGGER_SCHEDULER) ScheduledExecutorService scheduler,
+            @Named(ConfigModule.CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS) List<String> definitions,
             TriggerParser parser,
             FlightRecorderHelper helper,
             Harvester harvester,
             @Named(ConfigModule.CRYOSTAT_AGENT_SMART_TRIGGER_EVALUATION_PERIOD_MS)
                     long evaluationPeriodMs) {
-        return new TriggerEvaluator(scheduler, parser, helper, harvester, evaluationPeriodMs);
+        return new TriggerEvaluator(
+                scheduler, definitions, parser, helper, harvester, evaluationPeriodMs);
     }
 }

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -28,4 +28,5 @@ cryostat.agent.harvester.exit.max-size-b=0
 cryostat.agent.harvester.max-age-ms=0
 cryostat.agent.harvester.max-size-b=0
 
+cryostat.agent.smart-trigger.definitions=
 cryostat.agent.smart-trigger.evaluation.period-ms=1000


### PR DESCRIPTION
See #217 #197 #128 

This adds handling of a new config property to allow users to specify Smart Triggers by JVM system property or environment variable in addition to the previous Agent arguments method. This is useful for cases where it may be easier to add environment variables to the target application deployment than to modify the startup script to both add an Agent and append arguments for it. For example, in my typical `vertx-fib-demo` sample application, the gradle/jib build setup also uses an additional plugin for downloading, packaging, and configuring the Agent, but it doesn't (easily) allow for adding an argument to the Agent. This is probably a pretty rare corner case, as I would expect most users who are able to add the `-javaagent` flag are also able to add the argument after it, but this adds extra flexibility just in case.


```patch
diff --git a/smoketest.sh b/smoketest.sh
index 187c5a7e..f594c459 100755
--- a/smoketest.sh
+++ b/smoketest.sh
@@ -202,7 +202,7 @@ runDemoApps() {
     podman run \
         --name quarkus-test-agent-1 \
         --pod cryostat-pod \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -Dcom.sun.management.jmxremote.port=9097 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false -javaagent:/deployments/app/cryostat-agent.jar=[ThreadCount>0]~default.jfc,[ThreadCount>0&&TargetDuration>duration(\"30s\")]~Profiling" \
         --env QUARKUS_HTTP_PORT=10010 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent-1" \
@@ -214,14 +214,16 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_BASEURI="${protocol}://localhost:${webPort}/" \
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
+        --env CRYOSTAT_AGENT_API_WRITES_ENABLED="true" \
         --env CRYOSTAT_AGENT_HARVESTER_PERIOD_MS=60000 \
         --env CRYOSTAT_AGENT_HARVESTER_MAX_FILES=10 \
+        --env CRYOSTAT_AGENT_SMART_TRIGGER_DEFINITIONS="[ThreadCount>0&&TargetDuration>duration(\"1m\")]~default.jfc" \
         --rm -d quay.io/andrewazores/quarkus-test:latest
 
     podman run \
         --name quarkus-test-agent-2 \
         --pod cryostat-pod \
-        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar" \
+        --env JAVA_OPTS="-Dquarkus.http.host=0.0.0.0 -Djava.util.logging.manager=org.jboss.logmanager.LogManager -javaagent:/deployments/app/cryostat-agent.jar=[ThreadCount>0&&TargetDuration>duration(\"2m\")]~Profiling" \
         --env QUARKUS_HTTP_PORT=10011 \
         --env ORG_ACME_CRYOSTATSERVICE_ENABLED="false" \
         --env CRYOSTAT_AGENT_APP_NAME="quarkus-test-agent-2" \
@@ -234,6 +236,8 @@ runDemoApps() {
         --env CRYOSTAT_AGENT_TRUST_ALL="true" \
         --env CRYOSTAT_AGENT_AUTHORIZATION="Basic $(echo user:pass | base64)" \
         --env CRYOSTAT_AGENT_API_WRITES_ENABLED="true" \
+        --env CRYOSTAT_AGENT_HARVESTER_TEMPLATE="default" \
+        --env CRYOSTAT_AGENT_SMART_TRIGGER_EVALUATION_PERIOD_MS=10000 \
         --rm -d quay.io/andrewazores/quarkus-test:latest
 
     # copy a jboss-client.jar into /clientlib first
```