### PR TITLE
feat(attach): implement basic dynamic attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,19 +34,38 @@ is an available version upgrade and ensure both your Agent and server match this
 
 ### Build Requirements
 - Git
-- JDK11+
+- OpenJDK11+
 - Maven 3+
 
 Run Requirements:
-- An application JVM to attach this agent to
+- A OpenJDK11+ application JVM to attach this agent to
 - Configuration for the application JVM to load this agent
+- A [Cryostat server](https://github.com/cryostatio/cryostat) instance
 
+## Run
 
 An example for configuring a Quarkus application to use this agent and enable JMX:
 ```
 JAVA_OPTIONS="-Dcom.sun.management.jmxremote.port=9091 -Dcom.sun.management.jmxremote.rmi.port=9091 -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -javaagent:/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar"
 ```
-This assumes that the agent JAR has been included in the application image within `/deployments/app/`.
+This assumes that the agent JAR has been included in the application image within `/deployments/app/` or mounted as a
+volume at the same location.
+
+The agent JAR may also be loaded and dynamically attached to an already-running JVM. In this case, the agent JAR must
+again be already included in the application image mounted as a volume into the container at the same location. If this
+requirement is met, then the host JVM application may be started first without the Cryostat Agent with whatever its own
+standard launcher process looks like. Once that application is running, the Cryostat Agent can be launched as a separate
+process and asked to dynamically attach to the host application:
+```
+$ java -jar /path/to/cryostat-agent.jar -Dcryostat.agent.baseuri=http://cryostat.local
+```
+
+In this dynamic attachment mode, the agent [configuration](#configuration) options can be specified using the
+`-D`/`property` flag. [Smart triggers](#smart-triggers) can be specified using `--smartTrigger`. The optional PID is
+a positional argument and may be ignored or set to: `0` to request that the Agent launcher attempt to find exactly one
+candidate JVM application to dynamically attach to, exiting if zero or more than one applications are found; `*` to
+request that the Agent launch attempt to dynamically attach to every JVM application it finds; or a specific PID to
+request that the Agent attempt to dynamically attach only to that one PID.
 
 ## Harvester
 
@@ -55,7 +74,7 @@ Recording using a given event template on Agent initialization, and to periodica
 it to the Agent's associated Cryostat server. The Agent will also attempt to push the tail end of this recording on JVM
 shutdown so that the cause of an unexpected JVM shutdown might be captured for later analysis.
 
-## SMART TRIGGERS
+## Smart Triggers
 
 `cryostat-agent` supports Smart Triggers that listen to the values of the MBean Counters and can start recordings based
 on a set of constraints specified by the user.
@@ -130,7 +149,7 @@ Harvester period without a Harvester template, you can achieve a setup where dyn
 begin when trigger conditions are met, and their data is then periodically captured until the recording is manually
 stopped or the host JVM shuts down.
 
-## CONFIGURATION
+## Configuration
 
 `cryostat-agent` uses [smallrye-config](https://github.com/smallrye/smallrye-config) for configuration.
 Below is a list of configuration properties that can be used to influence how `cryostat-agent` runs

--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ These may be passed as an argument to the Cryostat Agent, for example:
 JAVA_OPTIONS="-javaagent:-Dcryostat.agent.baseuri=http://cryostat.local!/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=[ProcessCpuLoad>0.2]~profile
 ```
 
+(note the '!' separator between system properties overrides and Smart Triggers)
+
 or as a [configuration property](#configuration):
 
 ```

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Smart Triggers may define more complex conditions that test multiple metrics:
 These may be passed as an argument to the Cryostat Agent, for example:
 
 ```
-JAVA_OPTIONS="-javaagent:/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=[ProcessCpuLoad>0.2]~profile
+JAVA_OPTIONS="-javaagent:-Dcryostat.agent.baseuri=http://cryostat.local!/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=[ProcessCpuLoad>0.2]~profile
 ```
 
 or as a [configuration property](#configuration):

--- a/README.md
+++ b/README.md
@@ -61,11 +61,16 @@ $ java -jar /path/to/cryostat-agent.jar -Dcryostat.agent.baseuri=http://cryostat
 ```
 
 In this dynamic attachment mode, the agent [configuration](#configuration) options can be specified using the
-`-D`/`property` flag. [Smart triggers](#smart-triggers) can be specified using `--smartTrigger`. The optional PID is
-a positional argument and may be ignored or set to: `0` to request that the Agent launcher attempt to find exactly one
-candidate JVM application to dynamically attach to, exiting if zero or more than one applications are found; `*` to
-request that the Agent launch attempt to dynamically attach to every JVM application it finds; or a specific PID to
-request that the Agent attempt to dynamically attach only to that one PID.
+`-D`/`property` flag. These must be placed *after* the `-jar /path/to/cryostat-agent.jar` in order to be passed as
+arguments to the agent launcher - if they are passed *before* the `-jar` then they will be used by the `java` process
+as system properties on the agent launcher itself, rather than having them passed on to the injected instances.
+
+[Smart triggers](#smart-triggers) can be specified using `--smartTrigger`.
+
+The optional PID is a positional argument and may be ignored or set to: `0` to request that the Agent launcher attempt
+to find exactly one candidate JVM application to dynamically attach to, exiting if zero or more than one applications
+are found; `*` to request that the Agent launch attempt to dynamically attach to every JVM application it finds; or a
+specific PID to request that the Agent attempt to dynamically attach only to that one PID.
 
 ## Harvester
 

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
   <org.slf4j.version>2.0.12</org.slf4j.version>
   <org.projectnessie.cel.bom.version>0.4.4</org.projectnessie.cel.bom.version>
   <com.google.protobuf-java.version>3.22.3</com.google.protobuf-java.version>
+  <info.picocli.version>4.7.4</info.picocli.version>
   <com.redhat.insights.agent.version>0.9.1</com.redhat.insights.agent.version>
 
   <com.github.spotbugs.version>4.8.3</com.github.spotbugs.version>
@@ -176,6 +177,11 @@
         <artifactId>slf4j-api</artifactId>
       </exclusion>
     </exclusions>
+  </dependency>
+  <dependency>
+    <groupId>info.picocli</groupId>
+    <artifactId>picocli</artifactId>
+    <version>${info.picocli.version}</version>
   </dependency>
   <dependency>
     <groupId>org.projectnessie.cel</groupId>
@@ -278,6 +284,7 @@
       <configuration>
         <archive>
           <manifest>
+            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             <mainClass>${mainClass}</mainClass>
           </manifest>
           <manifestEntries>
@@ -348,6 +355,10 @@
               <relocation>
                 <pattern>com.fasterxml.jackson</pattern>
                 <shadedPattern>${shade.prefix}.com.fasterxml.jackson</shadedPattern>
+              </relocation>
+              <relocation>
+                <pattern>picocli</pattern>
+                <shadedPattern>${shade.prefix}.picocli</shadedPattern>
               </relocation>
             </relocations>
             <transformers>

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -128,6 +128,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
                                 properties,
                                 String.join(",", smartTriggers != null ? smartTriggers : List.of()))
                         .toAgentMain();
+        log.trace("agentmain arg: \"{}\"", agentmainArg);
         for (String pid : pids) {
             VirtualMachine vm = VirtualMachine.attach(pid);
             log.info("Injecting agent into PID {}", pid);

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -45,7 +45,7 @@ class AgentArgs {
         String pid = q.poll();
         String smartTriggers = q.poll();
         if (StringUtils.isBlank(pid)) {
-            pid = "0";
+            pid = Agent.AUTO_ATTACH_PID;
         }
         return new AgentArgs(pid, smartTriggers);
     }

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -15,10 +15,40 @@
  */
 package io.cryostat.agent;
 
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Queue;
+
+import io.cryostat.agent.util.StringUtils;
+
 class AgentArgs {
-    String pid;
+    private final String pid;
     // TODO refactor this and perform parsing earlier in execution
-    String smartTriggers;
+    private final String smartTriggers;
+
+    public AgentArgs(String pid, String smartTriggers) {
+        this.pid = pid;
+        this.smartTriggers = smartTriggers;
+    }
+
+    public String getPid() {
+        return pid;
+    }
+
+    public String getSmartTriggers() {
+        return smartTriggers;
+    }
+
+    public static AgentArgs from(String[] args) {
+        Queue<String> q = new ArrayDeque<>(Arrays.asList(args));
+        // FIXME this should not be specified by ordering but instead by key-value pairing
+        String pid = q.poll();
+        String smartTriggers = q.poll();
+        if (StringUtils.isBlank(pid)) {
+            pid = "0";
+        }
+        return new AgentArgs(pid, smartTriggers);
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -57,8 +57,9 @@ class AgentArgs {
                         Arrays.asList(props.split(",")).stream()
                                 .map(
                                         e -> {
-                                            String[] p = e.split("=");
-                                            return Pair.of(p[0], p[1]);
+                                            int idx = e.indexOf('=');
+                                            return Pair.of(
+                                                    e.substring(0, idx), e.substring(idx + 1));
                                         })
                                 .collect(
                                         Collectors.toMap(

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+class AgentArgs {
+    String pid;
+    // TODO refactor this and perform parsing earlier in execution
+    String smartTriggers;
+
+    @Override
+    public String toString() {
+        return "AgentArgs [pid=" + pid + ", smartTriggers=" + smartTriggers + "]";
+    }
+}

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -29,6 +29,7 @@ import io.cryostat.agent.util.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 
 class AgentArgs {
+    private static final String DELIMITER = "!";
     private final Map<String, String> properties;
     private final String smartTriggers;
 
@@ -49,7 +50,7 @@ class AgentArgs {
         Map<String, String> properties = new HashMap<>();
         String smartTriggers = "";
         if (StringUtils.isNotBlank(agentmainArg)) {
-            Queue<String> parts = new ArrayDeque<>(Arrays.asList(agentmainArg.split("!")));
+            Queue<String> parts = new ArrayDeque<>(Arrays.asList(agentmainArg.split(DELIMITER)));
             String props = parts.poll();
             if (StringUtils.isNotBlank(props)) {
                 properties =
@@ -82,6 +83,6 @@ class AgentArgs {
         if (StringUtils.isNotBlank(smartTriggers)) {
             parts.add(smartTriggers);
         }
-        return String.join("!", parts);
+        return String.join(DELIMITER, parts);
     }
 }

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -15,6 +15,7 @@
  */
 package io.cryostat.agent;
 
+import java.lang.instrument.Instrumentation;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -32,12 +33,23 @@ import org.apache.commons.lang3.tuple.Pair;
 
 class AgentArgs {
     private static final String DELIMITER = "!";
+    private final Instrumentation instrumentation;
     private final Map<String, String> properties;
     private final String smartTriggers;
 
-    public AgentArgs(Map<String, String> properties, String smartTriggers) {
+    public AgentArgs(
+            Instrumentation instrumentation, Map<String, String> properties, String smartTriggers) {
+        this.instrumentation = instrumentation;
         this.properties = Optional.ofNullable(properties).orElse(Collections.emptyMap());
         this.smartTriggers = StringUtils.defaultValue(smartTriggers, "");
+    }
+
+    public AgentArgs(Map<String, String> properties, String smartTriggers) {
+        this(null, properties, smartTriggers);
+    }
+
+    public Instrumentation getInstrumentation() {
+        return instrumentation;
     }
 
     public Map<String, String> getProperties() {
@@ -48,7 +60,7 @@ class AgentArgs {
         return smartTriggers;
     }
 
-    public static AgentArgs from(String agentmainArg) {
+    public static AgentArgs from(Instrumentation instrumentation, String agentmainArg) {
         Map<String, String> properties = new HashMap<>();
         String smartTriggers = "";
         if (StringUtils.isNotBlank(agentmainArg)) {
@@ -70,7 +82,7 @@ class AgentArgs {
             }
             smartTriggers = parts.poll();
         }
-        return new AgentArgs(properties, smartTriggers);
+        return new AgentArgs(instrumentation, properties, smartTriggers);
     }
 
     public String toAgentMain() {

--- a/src/main/java/io/cryostat/agent/AgentArgs.java
+++ b/src/main/java/io/cryostat/agent/AgentArgs.java
@@ -18,9 +18,11 @@ package io.cryostat.agent;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.stream.Collectors;
 
@@ -34,7 +36,7 @@ class AgentArgs {
     private final String smartTriggers;
 
     public AgentArgs(Map<String, String> properties, String smartTriggers) {
-        this.properties = properties;
+        this.properties = Optional.ofNullable(properties).orElse(Collections.emptyMap());
         this.smartTriggers = StringUtils.defaultValue(smartTriggers, "");
     }
 

--- a/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
+++ b/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
@@ -39,7 +39,6 @@ import com.redhat.insights.agent.shaded.reports.InsightsReport;
 import com.redhat.insights.agent.shaded.tls.PEMSupport;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 
 public class InsightsAgentHelper {
 
@@ -54,9 +53,9 @@ public class InsightsAgentHelper {
 
     private final Config config;
 
-    public InsightsAgentHelper(Instrumentation instrumentation) {
+    public InsightsAgentHelper(Config config, Instrumentation instrumentation) {
+        this.config = config;
         this.instrumentation = instrumentation;
-        this.config = ConfigProvider.getConfig();
     }
 
     public boolean isInsightsEnabled(PluginInfo pluginInfo) {

--- a/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
@@ -75,10 +75,10 @@ public class TriggerEvaluator {
         this.evaluationPeriodMs = evaluationPeriodMs;
     }
 
-    public void start(String[] args) {
+    public void start(String str) {
         this.stop();
-        parser.parse(args).forEach(this::registerTrigger);
-        parser.parse(definitions.toArray(new String[0])).forEach(this::registerTrigger);
+        parser.parse(str).forEach(this::registerTrigger);
+        parser.parse(String.join(",", definitions)).forEach(this::registerTrigger);
         this.start();
     }
 

--- a/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
@@ -39,19 +39,14 @@ public class TriggerParser {
         this.flightRecorderHelper = flightRecorderHelper;
     }
 
-    public List<SmartTrigger> parse(String[] args) {
+    public List<SmartTrigger> parse(String str) {
         List<SmartTrigger> triggers = new ArrayList<>();
-        if (args == null || args.length < 1) {
-            log.trace("Agent args were empty, no Triggers were defined");
+        if (StringUtils.isBlank(str)) {
+            log.warn("arg was blank, no Triggers were defined");
             return triggers;
         }
-        if (StringUtils.isBlank(args[0])) {
-            log.warn("Agent arg[0] was blank, no Triggers were defined");
-            return triggers;
-        }
-        String triggerDefinitions = args[0];
 
-        String[] expressions = triggerDefinitions.split(",");
+        String[] expressions = str.split(",");
         for (String s : expressions) {
             s = s.replaceAll("\\s", "");
             Matcher m = EXPRESSION_PATTERN.matcher(s);

--- a/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
@@ -42,7 +42,6 @@ public class TriggerParser {
     public List<SmartTrigger> parse(String str) {
         List<SmartTrigger> triggers = new ArrayList<>();
         if (StringUtils.isBlank(str)) {
-            log.warn("arg was blank, no Triggers were defined");
             return triggers;
         }
 

--- a/src/main/java/io/cryostat/agent/util/StringUtils.java
+++ b/src/main/java/io/cryostat/agent/util/StringUtils.java
@@ -25,4 +25,8 @@ public class StringUtils {
     public static boolean isNotBlank(String s) {
         return !isBlank(s);
     }
+
+    public static String defaultValue(String in, String def) {
+        return isNotBlank(in) ? in : def;
+    }
 }

--- a/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
+++ b/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
@@ -38,7 +38,6 @@ import com.redhat.insights.agent.SLF4JLogger;
 import com.redhat.insights.agent.shaded.InsightsReportController;
 import com.redhat.insights.agent.shaded.http.InsightsHttpClient;
 import org.eclipse.microprofile.config.Config;
-import org.eclipse.microprofile.config.ConfigProvider;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,16 +60,12 @@ public class InsightsAgentHelperTest {
     @Mock InsightsReportController controller;
     @Captor ArgumentCaptor<AgentConfiguration> configCaptor;
     @Captor ArgumentCaptor<Supplier<InsightsHttpClient>> clientSupplierCaptor;
-    private MockedStatic<ConfigProvider> providerStatic;
     MockedStatic<AgentBasicReport> reportStatic;
     MockedStatic<InsightsReportController> controllerStatic;
     InsightsAgentHelper helper;
 
     @BeforeEach
     void setupEach() {
-        providerStatic = Mockito.mockStatic(ConfigProvider.class);
-        providerStatic.when(() -> ConfigProvider.getConfig()).thenReturn(config);
-
         reportStatic = Mockito.mockStatic(AgentBasicReport.class);
         reportStatic.when(() -> AgentBasicReport.of(any())).thenReturn(report);
 
@@ -83,12 +78,11 @@ public class InsightsAgentHelperTest {
                 Collections.singletonMap("INSIGHTS_SVC", "http://insights-proxy.example.com:8080");
         when(pluginInfo.getEnv()).thenReturn(env);
 
-        this.helper = new InsightsAgentHelper(instrumentation);
+        this.helper = new InsightsAgentHelper(config, instrumentation);
     }
 
     @AfterEach
     void teardownEach() {
-        providerStatic.close();
         reportStatic.close();
         controllerStatic.close();
     }

--- a/src/test/java/io/cryostat/agent/triggers/TriggerParserTest.java
+++ b/src/test/java/io/cryostat/agent/triggers/TriggerParserTest.java
@@ -51,14 +51,14 @@ class TriggerParserTest {
     @NullSource
     void testEmptyCases(List<String> args) {
         MatcherAssert.assertThat(
-                parser.parse(args == null ? null : args.toArray(new String[0])),
+                parser.parse(args == null ? null : String.join(",", args.toArray(new String[0]))),
                 Matchers.equalTo(List.of()));
     }
 
     @Test
     void testSingleSimpleTrigger() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
-        String[] in = new String[] {"[ProcessCpuLoad>0.2]~profile"};
+        String in = "[ProcessCpuLoad>0.2]~profile";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(1));
@@ -78,8 +78,7 @@ class TriggerParserTest {
     @Test
     void testSingleComplexTrigger() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
-        String[] in =
-                new String[] {"[ProcessCpuLoad>0.2;TargetDuration>duration(\"30s\")]~profile"};
+        String in = "[ProcessCpuLoad>0.2;TargetDuration>duration(\"30s\")]~profile";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(1));
@@ -103,7 +102,7 @@ class TriggerParserTest {
     @Test
     void testSingleComplexTriggerSingleQuoted() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
-        String[] in = new String[] {"[ProcessCpuLoad>0.2;TargetDuration>duration('30s')]~profile"};
+        String in = "[ProcessCpuLoad>0.2;TargetDuration>duration('30s')]~profile";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(1));
@@ -127,10 +126,7 @@ class TriggerParserTest {
     @Test
     void testSingleComplexTriggerWithWhitespace() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
-        String[] in =
-                new String[] {
-                    "[ProcessCpuLoad > 0.2 ; TargetDuration > duration(\"30s\")]~profile"
-                };
+        String in = "[ProcessCpuLoad > 0.2 ; TargetDuration > duration(\"30s\")]~profile";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(1));
@@ -154,12 +150,10 @@ class TriggerParserTest {
     @Test
     void testMultipleComplexTriggerWithWhitespace() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
-        String[] in =
-                new String[] {
-                    "[ProcessCpuLoad>0.2 ; TargetDuration>duration(\"30s\")]~profile,"
-                            + " [(HeapMemoryUsagePercent > 50 && NonHeapMemoryUsage > 1) ||"
-                            + " SystemCpuLoad > 4 ; TargetDuration > duration(\"2m\")]~default.jfc"
-                };
+        String in =
+                "[ProcessCpuLoad>0.2 ; TargetDuration>duration(\"30s\")]~profile,"
+                        + " [(HeapMemoryUsagePercent > 50 && NonHeapMemoryUsage > 1) ||"
+                        + " SystemCpuLoad > 4 ; TargetDuration > duration(\"2m\")]~default.jfc";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(2));
@@ -203,12 +197,10 @@ class TriggerParserTest {
         Mockito.when(helper.isValidTemplate(Mockito.anyString()))
                 .thenReturn(true)
                 .thenReturn(false);
-        String[] in =
-                new String[] {
-                    "[ProcessCpuLoad>0.2 ; TargetDuration>duration(\"30s\")]~profile,"
-                            + " [(HeapMemoryUsagePercent > 50 && NonHeapMemoryUsage > 1) ||"
-                            + " SystemCpuLoad > 4 ; TargetDuration > duration(\"2m\")]~default.jfc"
-                };
+        String in =
+                "[ProcessCpuLoad>0.2 ; TargetDuration>duration(\"30s\")]~profile,"
+                        + " [(HeapMemoryUsagePercent > 50 && NonHeapMemoryUsage > 1) ||"
+                        + " SystemCpuLoad > 4 ; TargetDuration > duration(\"2m\")]~default.jfc";
         List<SmartTrigger> out = parser.parse(in);
 
         MatcherAssert.assertThat(out, Matchers.hasSize(1));


### PR DESCRIPTION
Based on #224
Related to #233

This implements basic dynamic attach. The Agent can be launched as a standalone Java process like:

```bash
$ java -jar target/cryostat-agent-0.4.0-SNAPSHOT.jar 1234 # 1234 is another JVM's pid
```

This will cause the Agent process to look up PID `1234` using its Attach providers. If `1234` is found as a valid PID then the Agent process will attach to PID `1234` and attempt to load the Agent's own JAR into that running JVM, which will then bootstrap into the normal Agent launch process. If `1234` is not found then nothing is bootstrapped. Instead of `1234` the wildcard `*` can also be specified, which will lead to the Agent JAR attempting to bootstrap itself into every JVM it finds. Finally, if the PID is not specified or is `0`, then the Agent will check if exactly one candidate JVM is available and attempt to bootstrap into that, failing if there are too many JVM candidates or none.

~~In this mode the Agent still tries to load its configuration entirely from the JVM it is bootstrapping into, which does not really make sense for a late-attaching Agent - the host application probably does not have Cryostat Agent-specific configuration properties if it was not launched with the Cryostat Agent to begin with. This will be addressed some time later in a follow-up PR.~~

Additional late-binding configuration options can be specified to the Agent launcher with command line options:

```bash
$ java -jar target/cryostat-agent-0.4.0-SNAPSHOT.jar \
-Dcryostat.agent.baseuri=http://cryostat.local \
--smartTrigger=[ProcessCpuLoad>0.2]~profile \
@/deployment/app/moreAgentArgs \
1234
```

Try `$ java -jar target/cryostat-agent-0.4.0-SNAPSHOT.jar -h` and see [picocli](https://picocli.info) for a more complete explanation of the available options and their behaviour. These late-binding configuration options are picked up by the Agent launcher process and serialized into a single `String` argument that is passed into the injected Agent instances, which they receive on their `agentmain(String arg)` and then deserialize again. System properties specified with `-D` are set onto the host JVM before the injected Agent attempts to read its configuration values, so from the Agent implementation POV this is identical to setting the `-D` or equivalent environment variable on the host JVM process itself. This mechanism does allow the user who controls the agent injection to override other arbitrary system properties of the host JVM at runtime, however if the user has enough access and ability to inject an agent then they can already exploit this without using the Cryostat Agent specifically.

To test:

```bash
$ ./mvnw clean install
$ gh repo clone andrewazores/quarkus-test
$ cd quarkus-test
$ git checkout agent-dynamic-attach
$ ./build.bash # build a quarkus-test image with the new agent included in the image but not launched with -javaagent
$ ./run.bash # run a quarkus-test container, then after a few seconds, spawn a Cryostat Agent process to dynamically attach to the quarkus server
```

----

Things to investigate:
1. Dynamic attach/agent JAR loading "remotely". If the host application is running in a container that does not already contain the agent JAR, how can we get the agent injected and dynamically attached to the application in the container without having to restart the container? Dynamic attach means the agent loading doesn't require a restart, but adding a new mounted volume to the container might. The attach mechanism, at least the one used in this PR, allows for attachment to a remote VM, but requesting the VM to load the agent requires a JAR path local to the VM's filesystem. Is there some way to get the VM to load from a `ByteArrayInputStream` or something so we can send it the JAR contents directly?
2. or 1b - is it feasible to rewrite parts of the agent to not actually rely on being part of the host application directly, but instead use only the local management agent (JMX)? Would also need to investigate how to ensure that's kept locked down and never exposed to any other processes, at least none outside of the container, if the agent launcher is the one turning that feature on. If this can be done then actually the agent would not need to inject itself into VMs but can run alongside them as a separate process and use local management RMI. This seems a bit hairy and is probably best avoided however. Perhaps that's best suited for another component that is not an agent, but rather a sidecar collector process, which may not implement all of the same features as the agent.
3. Watch mode? Currently the agent launcher will execute once, attempting to inject itself into one or more VMs, and then exit. If the user specified the `*` PID wildcard, it might also be useful to have a `--watch` option where the agent launcher becomes a daemon, injecting agent instances into new JVMs as they appear.