### PR TITLE
feat(insights): add config parameter to opt out of Insights

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.harvester.max-size-b` [`long`]: the JFR `maxsize` setting, specified in bytes, to apply to periodic uploads during the application lifecycle. Defaults to `0`, which means `unlimited`.
 - [ ] `cryostat.agent.smart-trigger.definitions` [`String[]`]: a comma-separated list of Smart Trigger definitions to load at startup. Defaults to the empty string: no Smart Triggers.
 - [ ] `cryostat.agent.smart-trigger.evaluation.period-ms` [`long`]: the length of time between Smart Trigger evaluations. Default `1000`.
+- [ ] `rht.insights.java.opt-out` [`boolean`]: for the Red Hat build of Cryostat, set this to true to disable data collection for Red Hat Insights. Defaults to `false`. Red Hat Insights data collection is always disabled for community builds of Cryostat.
 
 These properties can be set by JVM system properties or by environment variables. For example, the property
 `cryostat.agent.baseuri` can be set using `-Dcryostat.agent.baseuri=https://mycryostat.example.com:1234/` or

--- a/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
+++ b/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
@@ -45,6 +45,7 @@ import org.slf4j.LoggerFactory;
 public class InsightsAgentHelper {
 
     private static final String INSIGHTS_SVC = "INSIGHTS_SVC";
+    static final String RHT_INSIGHTS_JAVA_OPT_OUT = "rht.insights.java.opt-out";
 
     private static final InsightsLogger log =
             new SLF4JWrapper(LoggerFactory.getLogger(InsightsAgentHelper.class));
@@ -61,7 +62,10 @@ public class InsightsAgentHelper {
     }
 
     public boolean isInsightsEnabled(PluginInfo pluginInfo) {
-        return pluginInfo.getEnv().containsKey(INSIGHTS_SVC);
+        // Check if the user has opted out
+        boolean optingOut =
+                config.getOptionalValue(RHT_INSIGHTS_JAVA_OPT_OUT, boolean.class).orElse(false);
+        return pluginInfo.getEnv().containsKey(INSIGHTS_SVC) && !optingOut;
     }
 
     public void runInsightsAgent(PluginInfo pluginInfo) {

--- a/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
+++ b/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
@@ -105,6 +105,20 @@ public class InsightsAgentHelperTest {
     }
 
     @Test
+    void testInsightsOptingOut() {
+        when(config.getOptionalValue("rht.insights.java.opt-out", boolean.class))
+                .thenReturn(Optional.of(true));
+        Assertions.assertFalse(helper.isInsightsEnabled(pluginInfo));
+    }
+
+    @Test
+    void testInsightsNotOptingOut() {
+        when(config.getOptionalValue("rht.insights.java.opt-out", boolean.class))
+                .thenReturn(Optional.of(false));
+        Assertions.assertTrue(helper.isInsightsEnabled(pluginInfo));
+    }
+
+    @Test
     void testRunInsightsAgent() {
         when(config.getValue(ConfigModule.CRYOSTAT_AGENT_APP_NAME, String.class))
                 .thenReturn("test");


### PR DESCRIPTION
While it's currently possible to disable Insights support at the operator level, it would be useful to be able to do this for individual workloads. This adds a config property to do that.

Related to: https://github.com/cryostatio/cryostat/issues/1763