### PR TITLE
test(smart_triggers): add test case for single-quoted duration

### DIFF
--- a/src/test/java/io/cryostat/agent/triggers/TriggerParserTest.java
+++ b/src/test/java/io/cryostat/agent/triggers/TriggerParserTest.java
@@ -101,6 +101,30 @@ class TriggerParserTest {
     }
 
     @Test
+    void testSingleComplexTriggerSingleQuoted() {
+        Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
+        String[] in = new String[] {"[ProcessCpuLoad>0.2;TargetDuration>duration('30s')]~profile"};
+        List<SmartTrigger> out = parser.parse(in);
+
+        MatcherAssert.assertThat(out, Matchers.hasSize(1));
+        SmartTrigger trigger = out.get(0);
+
+        MatcherAssert.assertThat(
+                trigger.getExpression(),
+                Matchers.equalTo("ProcessCpuLoad>0.2;TargetDuration>duration('30s')"));
+        MatcherAssert.assertThat(trigger.getRecordingTemplateName(), Matchers.equalTo("profile"));
+        MatcherAssert.assertThat(
+                trigger.getDurationConstraint(),
+                Matchers.equalTo("TargetDuration>duration(\"30s\")"));
+        MatcherAssert.assertThat(
+                trigger.getTriggerCondition(), Matchers.equalTo("ProcessCpuLoad>0.2"));
+        MatcherAssert.assertThat(trigger.getState(), Matchers.equalTo(TriggerState.NEW));
+        MatcherAssert.assertThat(
+                trigger.getTargetDuration(), Matchers.equalTo(Duration.ofSeconds(30)));
+        MatcherAssert.assertThat(trigger.getTimeConditionFirstMet(), Matchers.nullValue());
+    }
+
+    @Test
     void testSingleComplexTriggerWithWhitespace() {
         Mockito.when(helper.isValidTemplate(Mockito.anyString())).thenReturn(true);
         String[] in =


### PR DESCRIPTION
Related to #253

Adds one extra test case to ensure that the `duration()` syntax accepts single-quoted values. This can be useful when deploying the Agent so the user has flexibility on where to use single and double quotes to avoid having to use escape sequences while still being able to use whitespace, or perhaps even variable interpolations, etc.

The implementation already handles this case so this is simply adding a test to catch any future regressions.
