### PR TITLE
feat(webserver): password length and username can be configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.webserver.host` [`String`]: the internal hostname or IP address for the embedded webserver to bind to. Default `0.0.0.0`.
 - [ ] `cryostat.agent.webserver.port` [`int`]: the internal port number for the embedded webserver to bind to. Default `9977`.
 - [ ] `cryostat.agent.webserver.credentials.user` [`String`]: the username used for `Basic` authorization on the embedded webserver. Default `user`.
-- [ ] `cryostat.agent.webserver.credentials.pass-length` [`int`]: the length of the generated password used for `Basic` authorization on the embedded webserver. Default `24`.
+- [ ] `cryostat.agent.webserver.credentials.pass.length` [`int`]: the length of the generated password used for `Basic` authorization on the embedded webserver. Default `24`.
+- [ ] `cryostat.agent.webserver.credentials.pass.hash-function` [`String`]: The name of the hash function to use when generating passwords. Default `SHA-256`.
 - [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. Default `cryostat-agent`.
 - [ ] `cryostat.agent.app.jmx.port` [`int`]: the JMX RMI port that the application is listening on. The default is to attempt to determine this from the `com.sun.management.jmxremote.port` system property.
 - [ ] `cryostat.agent.registration.retry-ms` [`long`]: the duration in milliseconds between attempts to register with the Cryostat server. Default `5000`.

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.webserver.port` [`int`]: the internal port number for the embedded webserver to bind to. Default `9977`.
 - [ ] `cryostat.agent.webserver.credentials.user` [`String`]: the username used for `Basic` authorization on the embedded webserver. Default `user`.
 - [ ] `cryostat.agent.webserver.credentials.pass.length` [`int`]: the length of the generated password used for `Basic` authorization on the embedded webserver. Default `24`.
-- [ ] `cryostat.agent.webserver.credentials.pass.hash-function` [`String`]: The name of the hash function to use when generating passwords. Default `SHA-256`.
+- [ ] `cryostat.agent.webserver.credentials.pass.hash-function` [`String`]: the name of the hash function to use when generating passwords. Default `SHA-256`.
 - [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. Default `cryostat-agent`.
 - [ ] `cryostat.agent.app.jmx.port` [`int`]: the JMX RMI port that the application is listening on. The default is to attempt to determine this from the `com.sun.management.jmxremote.port` system property.
 - [ ] `cryostat.agent.registration.retry-ms` [`long`]: the duration in milliseconds between attempts to register with the Cryostat server. Default `5000`.

--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ and how it advertises itself to a Cryostat server instance. Required properties 
 - [ ] `cryostat.agent.webclient.response.timeout-ms` [`long`]: the duration in milliseconds to wait for HTTP requests to the Cryostat server to respond. Default `1000`.
 - [ ] `cryostat.agent.webserver.host` [`String`]: the internal hostname or IP address for the embedded webserver to bind to. Default `0.0.0.0`.
 - [ ] `cryostat.agent.webserver.port` [`int`]: the internal port number for the embedded webserver to bind to. Default `9977`.
+- [ ] `cryostat.agent.webserver.credentials.user` [`String`]: the username used for `Basic` authorization on the embedded webserver. Default `user`.
+- [ ] `cryostat.agent.webserver.credentials.pass-length` [`int`]: the length of the generated password used for `Basic` authorization on the embedded webserver. Default `24`.
 - [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. Default `cryostat-agent`.
 - [ ] `cryostat.agent.app.jmx.port` [`int`]: the JMX RMI port that the application is listening on. The default is to attempt to determine this from the `com.sun.management.jmxremote.port` system property.
 - [ ] `cryostat.agent.registration.retry-ms` [`long`]: the duration in milliseconds between attempts to register with the Cryostat server. Default `5000`.

--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ stopped or the host JVM shuts down.
 
 `cryostat-agent` uses [smallrye-config](https://github.com/smallrye/smallrye-config) for configuration.
 Below is a list of configuration properties that can be used to influence how `cryostat-agent` runs
-and how it advertises itself to a Cryostat server instance. Required properties are indicated with a checked box.
+and how it advertises itself to a Cryostat server instance. Properties that require configuration are indicated with a checked box.
 
 - [x] `cryostat.agent.baseuri` [`java.net.URI`]: the URL location of the Cryostat server backend that this agent advertises itself to.
 - [x] `cryostat.agent.baseuri-range` [`String`]: a `String` representing the `io.cryostat.agent.ConfigModule.UriRange` enum level that restricts the acceptable hosts specified in the `cryostat.agent.baseuri` property. This is used to control the server locations that this Cryostat Agent instance is willing to register itself with. Default `dns_local`, which means any IP or hostname that is or resolves to `localhost`, a link-local IP address, an IP address from a private range block, or a hostname ending in `.local` will be accepted. If a `cryostat.agent.baseuri` is specified with a host outside of this range then the Agent will refuse to start. Acceptable values are: `loopback`, `link_local`, `site_local`, `dns_local`, and `public`. Each higher/more relaxed level implies that each lower level is also acceptable.

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -208,8 +208,8 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER)
-    public static int provideCryostatAgentWebserverCredentialsUser(Config config) {
-        return config.getValue(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER, int.class);
+    public static String provideCryostatAgentWebserverCredentialsUser(Config config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER, String.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -64,6 +64,10 @@ public abstract class ConfigModule {
 
     public static final String CRYOSTAT_AGENT_WEBSERVER_HOST = "cryostat.agent.webserver.host";
     public static final String CRYOSTAT_AGENT_WEBSERVER_PORT = "cryostat.agent.webserver.port";
+    public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER =
+            "cryostat.agent.webserver.credentials.user";
+    public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH =
+            "cryostat.agent.webserver.credentials.pass-length";
 
     public static final String CRYOSTAT_AGENT_APP_NAME = "cryostat.agent.app.name";
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
@@ -199,6 +203,20 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_WEBSERVER_PORT)
     public static int provideCryostatAgentWebserverPort(Config config) {
         return config.getValue(CRYOSTAT_AGENT_WEBSERVER_PORT, int.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER)
+    public static int provideCryostatAgentWebserverCredentialsUser(Config config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER, int.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH)
+    public static int provideCryostatAgentWebserverCredentialsPassLength(Config config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH, int.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -21,6 +21,8 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.UnknownHostException;
 import java.security.AccessController;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Arrays;
@@ -66,8 +68,10 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_WEBSERVER_PORT = "cryostat.agent.webserver.port";
     public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER =
             "cryostat.agent.webserver.credentials.user";
+    public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_HASH_FUNCTION =
+            "cryostat.agent.webserver.credentials.pass.hash-function";
     public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH =
-            "cryostat.agent.webserver.credentials.pass-length";
+            "cryostat.agent.webserver.credentials.pass.length";
 
     public static final String CRYOSTAT_AGENT_APP_NAME = "cryostat.agent.app.name";
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
@@ -210,6 +214,21 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER)
     public static String provideCryostatAgentWebserverCredentialsUser(Config config) {
         return config.getValue(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER, String.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_HASH_FUNCTION)
+    public static MessageDigest provideCryostatAgentWebserverCredentialsPassHashFunction(
+            Config config) {
+        try {
+            String id =
+                    config.getValue(
+                            CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_HASH_FUNCTION, String.class);
+            return MessageDigest.getInstance(id);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException(e);
+        }
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -16,7 +16,6 @@
 package io.cryostat.agent;
 
 import java.io.BufferedInputStream;
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -65,6 +64,7 @@ import org.apache.http.entity.ContentType;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.entity.mime.FormBodyPartBuilder;
 import org.apache.http.entity.mime.MultipartEntityBuilder;
+import org.apache.http.entity.mime.content.ByteArrayBody;
 import org.apache.http.entity.mime.content.InputStreamBody;
 import org.apache.http.entity.mime.content.StringBody;
 import org.slf4j.Logger;
@@ -267,10 +267,10 @@ public class CryostatClient {
                         .addPart(
                                 FormBodyPartBuilder.create(
                                                 "password",
-                                                new InputStreamBody(
-                                                        new ByteArrayInputStream(
-                                                                credentials.pass()),
-                                                        ContentType.TEXT_PLAIN))
+                                                new ByteArrayBody(
+                                                        credentials.pass(),
+                                                        ContentType.TEXT_PLAIN,
+                                                        "pass"))
                                         .build())
                         .addPart(
                                 FormBodyPartBuilder.create(

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -93,10 +93,20 @@ public abstract class MainModule {
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER) String user,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH) int passLength,
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
             Lazy<Registration> registration) {
         return new WebServer(
-                remoteContexts, cryostat, executor, host, port, callback, registration);
+                remoteContexts,
+                cryostat,
+                executor,
+                host,
+                port,
+                user,
+                passLength,
+                callback,
+                registration);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -17,6 +17,7 @@ package io.cryostat.agent;
 
 import java.net.URI;
 import java.security.KeyManagementException;
+import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.CertificateException;
@@ -93,6 +94,8 @@ public abstract class MainModule {
             ScheduledExecutorService executor,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_HOST) String host,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_PORT) int port,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_HASH_FUNCTION)
+                    MessageDigest digest,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_USER) String user,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH) int passLength,
             @Named(ConfigModule.CRYOSTAT_AGENT_CALLBACK) URI callback,
@@ -103,6 +106,7 @@ public abstract class MainModule {
                 executor,
                 host,
                 port,
+                digest,
                 user,
                 passLength,
                 callback,

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -18,7 +18,6 @@ package io.cryostat.agent;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
-import java.security.NoSuchAlgorithmException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collection;
@@ -104,36 +103,31 @@ public class Registration {
                             }
                             executor.submit(
                                     () -> {
-                                        try {
-                                            webServer
-                                                    .generateCredentials()
-                                                    .handle(
-                                                            (v, t) -> {
-                                                                if (t != null) {
-                                                                    executor.schedule(
-                                                                            () ->
-                                                                                    notify(
-                                                                                            RegistrationEvent
-                                                                                                    .State
-                                                                                                    .UNREGISTERED),
-                                                                            registrationRetryMs,
-                                                                            TimeUnit.MILLISECONDS);
-                                                                    log.error(
-                                                                            "Failed to generate"
+                                        webServer
+                                                .generateCredentials()
+                                                .handle(
+                                                        (v, t) -> {
+                                                            if (t != null) {
+                                                                executor.schedule(
+                                                                        () ->
+                                                                                notify(
+                                                                                        RegistrationEvent
+                                                                                                .State
+                                                                                                .UNREGISTERED),
+                                                                        registrationRetryMs,
+                                                                        TimeUnit.MILLISECONDS);
+                                                                log.error(
+                                                                        "Failed to generate"
                                                                                 + " credentials",
-                                                                            t);
-                                                                    throw new CompletionException(
-                                                                            t);
-                                                                }
-                                                                ;
-                                                                notify(
-                                                                        RegistrationEvent.State
-                                                                                .REFRESHING);
-                                                                return v;
-                                                            });
-                                        } catch (NoSuchAlgorithmException nsae) {
-                                            log.error("Could not regenerate credentials", nsae);
-                                        }
+                                                                        t);
+                                                                throw new CompletionException(t);
+                                                            }
+                                                            ;
+                                                            notify(
+                                                                    RegistrationEvent.State
+                                                                            .REFRESHING);
+                                                            return v;
+                                                        });
                                     });
                             break;
                         case REGISTERED:

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -363,19 +363,43 @@ class WebServer {
         }
 
         private byte randomAlphabetical(boolean upperCase) throws NoSuchAlgorithmException {
-            return randomChar(upperCase ? 'A' : 'a', 26);
+            return upperCase ? randomAsciiChar('A', 'Z') : randomAsciiChar('a', 'z');
         }
 
         private byte randomNumeric() throws NoSuchAlgorithmException {
-            return randomChar('0', 10);
+            return randomAsciiChar('0', '9');
         }
 
         private byte randomSymbol() throws NoSuchAlgorithmException {
-            return randomChar('!', 14);
+            switch (random.nextInt(4)) {
+                case 0:
+                    return randomAsciiChar('!', '/');
+                case 1:
+                    return randomAsciiChar(':', '@');
+                case 2:
+                    return randomAsciiChar('[', '`');
+                default:
+                    return randomAsciiChar('{', '~');
+            }
         }
 
-        private byte randomChar(int offset, int range) throws NoSuchAlgorithmException {
-            return (byte) (random.nextInt(range) + offset);
+        private byte randomAsciiChar(char start, char end) throws NoSuchAlgorithmException {
+            if (start < 0 || start > 127) {
+                throw new IllegalArgumentException(
+                        String.format("start byte '%d' is out of ASCII range", (byte) start));
+            }
+            if (end < 0 || end > 127) {
+                throw new IllegalArgumentException(
+                        String.format("end byte '%d' is out of ASCII range", (byte) end));
+            }
+            if (start == end) {
+                throw new IllegalArgumentException("start and end bytes cannot be equal");
+            }
+            if (start > end) {
+                throw new IllegalArgumentException("start byte cannot be greater than end byte");
+            }
+            int diff = end - start;
+            return (byte) (random.nextInt(diff + 1) + start);
         }
 
         private static byte[] hash(String pass) throws NoSuchAlgorithmException {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -337,33 +337,10 @@ class WebServer {
         }
 
         private byte randomAscii() throws NoSuchAlgorithmException {
-            return randomAsciiChar((char) 33, (char) 126);
-        }
-
-        private byte randomAsciiChar(char start, char end) throws NoSuchAlgorithmException {
-            if (start < 0 || start > 127) {
-                throw new IllegalArgumentException(
-                        String.format("start byte '%d' is out of ASCII range", (byte) start));
-            }
-            if (start < 33 || start > 126) {
-                throw new IllegalArgumentException(
-                        String.format(
-                                "start byte '%d' is out of ASCII printable range", (byte) start));
-            }
-            if (end < 0 || end > 127) {
-                throw new IllegalArgumentException(
-                        String.format("end byte '%d' is out of ASCII range", (byte) end));
-            }
-            if (end < 33 || end > 126) {
-                throw new IllegalArgumentException(
-                        String.format("end byte '%d' is out of ASCII printable range", (byte) end));
-            }
-            if (start == end) {
-                throw new IllegalArgumentException("start and end bytes cannot be equal");
-            }
-            if (start > end) {
-                throw new IllegalArgumentException("start byte cannot be greater than end byte");
-            }
+            // ASCII printable characters range from 33 to 126. Other values are null, whitespace,
+            // and various control characters
+            char start = (char) 33;
+            char end = (char) 126;
             int diff = end - start;
             return (byte) (random.nextInt(diff + 1) + start);
         }

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -297,15 +297,14 @@ class WebServer {
 
     static class Credentials {
 
-        private final String user;
-        private final int passLength;
         private final SecureRandom random = new SecureRandom();
+        private final String user;
+        private final byte[] pass;
         private byte[] passHash = new byte[0];
-        private byte[] pass = new byte[0];
 
         Credentials(String user, int passLength) {
             this.user = user;
-            this.passLength = passLength;
+            this.pass = new byte[passLength];
         }
 
         synchronized boolean checkUserInfo(String username, String password)
@@ -318,8 +317,6 @@ class WebServer {
         synchronized void regenerate() throws NoSuchAlgorithmException {
             this.clear();
 
-            this.pass = new byte[passLength];
-
             // guarantee at least one character from each class
             int idx = 0;
             this.pass[idx++] = randomSymbol();
@@ -327,7 +324,7 @@ class WebServer {
             this.pass[idx++] = randomAlphabetical(random.nextBoolean());
 
             // fill remaining slots with randomly assigned characters across classes
-            for (; idx < passLength; idx++) {
+            for (; idx < this.pass.length; idx++) {
                 switch (random.nextInt(3)) {
                     case 0:
                         this.pass[idx] = randomSymbol();
@@ -374,7 +371,7 @@ class WebServer {
         }
 
         private byte randomSymbol() throws NoSuchAlgorithmException {
-            return randomChar(33, 14);
+            return randomChar('!', 14);
         }
 
         private byte randomChar(int offset, int range) throws NoSuchAlgorithmException {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -321,7 +321,8 @@ class WebServer {
             int idx = 0;
             this.pass[idx++] = randomSymbol();
             this.pass[idx++] = randomNumeric();
-            this.pass[idx++] = randomAlphabetical(random.nextBoolean());
+            this.pass[idx++] = randomAlphabetical(true);
+            this.pass[idx++] = randomAlphabetical(false);
 
             // fill remaining slots with randomly assigned characters across classes
             for (; idx < this.pass.length; idx++) {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -309,12 +309,9 @@ class WebServer {
         }
 
         synchronized void regenerate() {
-            this.clear();
-
             for (int idx = 0; idx < this.pass.length; idx++) {
                 this.pass[idx] = randomAscii();
             }
-
             this.passHash = hash(this.pass);
         }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -321,19 +321,23 @@ class WebServer {
             this.pass = new byte[passLength];
 
             // guarantee at least one character from each class
-            this.pass[0] = randomSymbol();
-            this.pass[1] = randomNumeric();
-            this.pass[2] = randomAlphabetical(random.nextBoolean());
+            int idx = 0;
+            this.pass[idx++] = randomSymbol();
+            this.pass[idx++] = randomNumeric();
+            this.pass[idx++] = randomAlphabetical(random.nextBoolean());
 
             // fill remaining slots with randomly assigned characters across classes
-            for (int i = 3; i < passLength; i++) {
-                int s = random.nextInt(3);
-                if (s == 0) {
-                    this.pass[i] = randomSymbol();
-                } else if (s == 1) {
-                    this.pass[i] = randomNumeric();
-                } else {
-                    this.pass[i] = randomAlphabetical(random.nextBoolean());
+            for (; idx < passLength; idx++) {
+                switch (random.nextInt(3)) {
+                    case 0:
+                        this.pass[idx] = randomSymbol();
+                        break;
+                    case 1:
+                        this.pass[idx] = randomNumeric();
+                        break;
+                    default:
+                        this.pass[idx] = randomAlphabetical(random.nextBoolean());
+                        break;
                 }
             }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -379,7 +379,7 @@ class WebServer {
         }
 
         private static byte[] hash(String pass) throws NoSuchAlgorithmException {
-            return hash(pass.getBytes(StandardCharsets.UTF_8));
+            return hash(pass.getBytes(StandardCharsets.US_ASCII));
         }
 
         private static byte[] hash(byte[] bytes) throws NoSuchAlgorithmException {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -317,35 +317,8 @@ class WebServer {
         synchronized void regenerate() throws NoSuchAlgorithmException {
             this.clear();
 
-            // guarantee at least one character from each class
-            int idx = 0;
-            this.pass[idx++] = randomSymbol();
-            this.pass[idx++] = randomNumeric();
-            this.pass[idx++] = randomAlphabetical(true);
-            this.pass[idx++] = randomAlphabetical(false);
-
-            // fill remaining slots with randomly assigned characters across classes
-            for (; idx < this.pass.length; idx++) {
-                switch (random.nextInt(3)) {
-                    case 0:
-                        this.pass[idx] = randomSymbol();
-                        break;
-                    case 1:
-                        this.pass[idx] = randomNumeric();
-                        break;
-                    default:
-                        this.pass[idx] = randomAlphabetical(random.nextBoolean());
-                        break;
-                }
-            }
-
-            // randomly shuffle the characters
-            // https://en.wikipedia.org/wiki/Fisher%E2%80%93Yates_shuffle
-            for (int i = this.pass.length - 1; i > 1; i--) {
-                int j = random.nextInt(i);
-                byte b = this.pass[i];
-                this.pass[i] = this.pass[j];
-                this.pass[j] = b;
+            for (int idx = 0; idx < this.pass.length; idx++) {
+                this.pass[idx] = randomAscii();
             }
 
             this.passHash = hash(this.pass);
@@ -363,25 +336,8 @@ class WebServer {
             Arrays.fill(this.pass, (byte) 0);
         }
 
-        private byte randomAlphabetical(boolean upperCase) throws NoSuchAlgorithmException {
-            return upperCase ? randomAsciiChar('A', 'Z') : randomAsciiChar('a', 'z');
-        }
-
-        private byte randomNumeric() throws NoSuchAlgorithmException {
-            return randomAsciiChar('0', '9');
-        }
-
-        private byte randomSymbol() throws NoSuchAlgorithmException {
-            switch (random.nextInt(4)) {
-                case 0:
-                    return randomAsciiChar('!', '/');
-                case 1:
-                    return randomAsciiChar(':', '@');
-                case 2:
-                    return randomAsciiChar('[', '`');
-                default:
-                    return randomAsciiChar('{', '~');
-            }
+        private byte randomAscii() throws NoSuchAlgorithmException {
+            return randomAsciiChar((char) 33, (char) 126);
         }
 
         private byte randomAsciiChar(char start, char end) throws NoSuchAlgorithmException {
@@ -389,9 +345,18 @@ class WebServer {
                 throw new IllegalArgumentException(
                         String.format("start byte '%d' is out of ASCII range", (byte) start));
             }
+            if (start < 33 || start > 126) {
+                throw new IllegalArgumentException(
+                        String.format(
+                                "start byte '%d' is out of ASCII printable range", (byte) start));
+            }
             if (end < 0 || end > 127) {
                 throw new IllegalArgumentException(
                         String.format("end byte '%d' is out of ASCII range", (byte) end));
+            }
+            if (end < 33 || end > 126) {
+                throw new IllegalArgumentException(
+                        String.format("end byte '%d' is out of ASCII printable range", (byte) end));
             }
             if (start == end) {
                 throw new IllegalArgumentException("start and end bytes cannot be equal");

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -10,6 +10,8 @@ cryostat.agent.webclient.connect.timeout-ms=1000
 cryostat.agent.webclient.response.timeout-ms=1000
 cryostat.agent.webserver.host=0.0.0.0
 cryostat.agent.webserver.port=9977
+cryostat.agent.webserver.credentials.user=user
+cryostat.agent.webserver.credentials.pass-length=24
 
 cryostat.agent.authorization=None
 cryostat.agent.callback=

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -11,7 +11,8 @@ cryostat.agent.webclient.response.timeout-ms=1000
 cryostat.agent.webserver.host=0.0.0.0
 cryostat.agent.webserver.port=9977
 cryostat.agent.webserver.credentials.user=user
-cryostat.agent.webserver.credentials.pass-length=24
+cryostat.agent.webserver.credentials.pass.hash-function=SHA-256
+cryostat.agent.webserver.credentials.pass.length=24
 
 cryostat.agent.authorization=None
 cryostat.agent.callback=


### PR DESCRIPTION
Fixes #341

- makes the webserver credential username configurable. Defaults to `user` as before, but this can be overridden if some need arises.
- makes the webserver credential password length configurable. This is always randomly generated, but the length was previously hardcoded to 24 characters. Now this can be configured, but continues to default to 24.
- expands the set of characters that can be generated for the password to include more of the ASCII symbols set. This increases password strength. Also simplifies the logic to just fill the password with any printable ASCII character, instead of trying to require at least one character from each of specific ranges first and then filling the remainder.
