### PR TITLE
feat(CI): Build container image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,7 +35,7 @@ jobs:
     - name: Fail if PR and safe-to-test label NOT applied
       if: ${{ github.event_name == 'pull_request_target' && !contains(github.event.pull_request.labels.*.name, 'safe-to-test') }}
       run: exit 1
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -76,7 +76,7 @@ jobs:
     outputs:
       image: ${{ steps.push-to-quay.outputs.image }}
     env:
-      IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
+      IMAGE_VERSION: ${{ needs.build-agent.outputs.image-version }}
     name: Build Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -96,8 +96,8 @@ jobs:
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.CI_IMG }}
-        archs: amd64
-        tags: ${{ env.agent-version }} ${{env.DATE_TAG}}
+        archs: amd64, arm64
+        tags: ${{ env.agent-version }} ${{env.DATE_TAG}} latest
         context: quarkus-agent
         containerfiles: |
           ./quarkus-agent/src/main/docker/Dockerfile.jvm

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -90,7 +90,7 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-build-
           ${{ runner.os }}-
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -5,38 +5,27 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  #push:
-  #  branches:
-  #    - main
-  #    - v[0-9]+
-  #    - v[0-9]+.[0-9]+
-  #    - cryostat-v[0-9]+.[0-9]+
-  issues:
-    types:
-      - opened
-      - edited
-      - reopened
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - reopened
-      - labeled
-      - synchronize
+  push:
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+      - cryostat-v[0-9]+.[0-9]+
 
 env:
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
-  CI_USER: miwan
-  CI_REGISTRY: quay.io/miwan
-  CI_IMG: quay.io/miwan/quarkus-test
+  CI_USER: cryostat+bot
+  CI_REGISTRY: quay.io/cryostat
+  CI_IMG: quay.io/cryostat/quarkus-test
 
 jobs:
   check-before-build:
     runs-on: ubuntu-latest
+    if: ${{ github.repository_owner == 'cryostatio' }}
     steps:
     - name: Fail if safe-to-test is not applied
-      if: github.repository_owner == 'cryostatio' && (!contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+      if: (!contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
       run: exit 1
 
   build-agent:
@@ -97,7 +86,7 @@ jobs:
         cache: 'maven'
     - uses: actions/checkout@v4
       with:
-        repository: mwangggg/quarkus-test
+        repository: ${{ github.repository_owner }}/quarkus-test
         ref: main
         submodules: true
         fetch-depth: 0
@@ -148,7 +137,7 @@ jobs:
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
-        password: ${{ secrets.QUAY_PASSWORD }}
+        password: ${{ secrets.REPOSITORY_PASSWORD }}
     - name: store quarkus-test image as output
       id: quarkus-test-image
       run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -56,7 +56,7 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
@@ -79,11 +79,11 @@ jobs:
       IMAGE_VERSION: ${{ needs.build-agent.outputs.image-version }}
     name: Build Java ${{ matrix.java }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    - uses: actions/cache@v3
+    - uses: actions/cache@v4
       with:
         path: ~/.m2
         key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
@@ -95,7 +95,7 @@ jobs:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
         cache: 'maven'
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         repository: mwangggg/quarkus-test
         ref: main

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -52,7 +52,6 @@ jobs:
     - id: get-agent-version
       run: |
         echo "agent-version=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)" >> $GITHUB_OUTPUT
-        - uses: actions/setup-java@v3
     - uses: actions/setup-java@v3
       with:
         java-version: '17'

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -5,62 +5,108 @@ concurrency:
   cancel-in-progress: true
 
 on:
-  push:
-    branches:
-      - main
-      - v[0-9]+
-      - v[0-9]+.[0-9]+
-      - cryostat-v[0-9]+.[0-9]+
+  #push:
+  #  branches:
+  #    - main
+  #    - v[0-9]+
+  #    - v[0-9]+.[0-9]+
+  #    - cryostat-v[0-9]+.[0-9]+
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - labeled
+      - synchronize
 
 env:
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
-  CI_USER: cryostat+bot
-  CI_REGISTRY: quay.io/cryostat
-  CI_IMG: quay.io/cryostat/quarkus-test
+  CI_USER: miwan
+  CI_REGISTRY: quay.io/miwan
+  CI_IMG: quay.io/miwan/quarkus-test
 
 jobs:
-  get-pom-properties:
+  check-before-build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - name: Fail if safe-to-test is not applied
+      if: github.repository_owner == 'cryostatio' && (!contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
+      run: exit 1
+
+  build-agent:
+    runs-on: ubuntu-latest
+    needs: [check-before-build]
+    outputs: 
+      image-version: ${{ steps.get-agent-version.outputs.agent-version }}
+    steps:
+    - uses: actions/checkout@v4
       with:
         submodules: true
         fetch-depth: 0
-    - id: query-pom
-      name: Get properties from POM
-      # Query POM image version and save as output parameter
+    - id: get-agent-version
       run: |
-        IMAGE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
-        echo "::set-output name=image-version::$IMAGE_VERSION"
-    outputs:
-      image-version: ${{ steps.query-pom.outputs.image-version }}
+        echo "agent-version=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)" >> $GITHUB_OUTPUT
+        - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v3
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+    - uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
+    - run: mvn -B -U clean install
 
-  build-and-test:
+  build-quarkus-test-app:
+    needs: [build-agent]
     runs-on: ubuntu-latest
-    needs: [get-pom-properties]
     strategy:
       matrix:
         java: ['17']
-    env:
-      IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
-      cache-name: cache-yarn
-    name: Build and test Java ${{ matrix.java }}
     permissions:
       packages: write
       contents: read
-    if: ${{ github.repository_owner == 'cryostatio' }}
+      pull-requests: write
+      statuses: write
+    outputs:
+      image: ${{ steps.push-to-quay.outputs.image }}
+    env:
+      IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
+    name: Build Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v3
       with:
         submodules: true
         fetch-depth: 0
+    - uses: actions/cache@v3
+      with:
+        path: ~/.m2
+        key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-build-
+          ${{ runner.os }}-
     - uses: actions/setup-java@v3
       with:
         java-version: ${{ matrix.java }}
         distribution: 'temurin'
-        cache: 'maven'clear
-        
+        cache: 'maven'
+    - uses: actions/checkout@v3
+      with:
+        repository: miwan/quarkus-test
+        ref: main
+        submodules: true
+        fetch-depth: 0
+    - name: maven-settings
+      uses: s4u/maven-settings-action@v2
+      with:
+        servers: '[{"id": "github", "username": "dummy", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
+        githubServer: false
     - name: Install podman v4
       run: |
         echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
@@ -83,16 +129,15 @@ jobs:
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
     - name: Build application
-      run: ./mvnw -B -U clean verify
-    - name: Delete local integration test image
-      run: podman rmi ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
-      continue-on-error: true
+      run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.IMAGE_VERSION }} clean verify
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build container images and manifest
       id: buildah-build
       uses: redhat-actions/buildah-build@v2
       with:
         image: ${{ env.CI_IMG }}
-        archs: amd64, arm64
+        archs: amd64
         tags: ${{ env.IMAGE_VERSION }}
         containerfiles: |
           ./src/main/docker/Dockerfile.jvm
@@ -100,10 +145,31 @@ jobs:
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: cryostat
+        image: quarkus-test
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
-        password: ${{ secrets.REGISTRY_PASSWORD }}
-    - name: Print image URL
-      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"
+        password: ${{ secrets.QUAY_PASSWORD }}
+    - name: store quarkus-test image as output
+      id: quarkus-test-image
+      run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> "$GITHUB_OUTPUT"
+
+  comment-image:
+    runs-on: ubuntu-latest
+    needs: [build-quarkus-test-app]
+    env:
+      image: ${{ needs.build-quarkus-test-app.outputs.image }}
+    permissions:
+      pull-requests: write
+    steps:
+    - name: Create markdown table
+      id: md-table
+      uses: petems/csv-to-md-table-action@v3.0.0
+      with:
+        csvinput: |
+          ARCH, IMAGE
+          amd64, ${{ env.image }}
+    - uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |-
+          ${{ steps.md-table.outputs.markdown-table }}

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -97,7 +97,7 @@ jobs:
         cache: 'maven'
     - uses: actions/checkout@v3
       with:
-        repository: miwan/quarkus-test
+        repository: mwangggg/quarkus-test
         ref: main
         submodules: true
         fetch-depth: 0

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -74,9 +74,9 @@ jobs:
       pull-requests: write
       statuses: write
     outputs:
-      image: ${{ steps.push-to-quay.outputs.image }}
+      quay-image: ${{ steps.quakus-test-image.outputs.image }}
     env:
-      IMAGE_VERSION: ${{ needs.build-agent.outputs.image-version }}
+      agent-version: ${{ needs.build-agent.outputs.image-version }}
     name: Build Java ${{ matrix.java }}
     steps:
     - uses: actions/checkout@v4
@@ -128,7 +128,7 @@ jobs:
     - name: Set DOCKER_HOST environment variable
       run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
     - name: Build application
-      run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.IMAGE_VERSION }} clean verify
+      run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.agent-version }} clean verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     - name: Build container images and manifest
@@ -137,7 +137,7 @@ jobs:
       with:
         image: ${{ env.CI_IMG }}
         archs: amd64
-        tags: ${{ env.IMAGE_VERSION }}
+        tags: ${{ env.agent-version }}
         containerfiles: |
           ./src/main/docker/Dockerfile.jvm
     - name: Push to quay.io
@@ -157,7 +157,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-quarkus-test-app]
     env:
-      image: ${{ needs.build-quarkus-test-app.outputs.image }}
+      image: ${{ needs.build-quarkus-test-app.outputs.quay-image }}
     permissions:
       pull-requests: write
     steps:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -21,17 +21,10 @@ env:
   CI_IMG: quay.io/redhat-java-monitoring/quarkus-cryostat-agent
 
 jobs:
-  check-before-build:
-    runs-on: ubuntu-latest
-    if: ${{ github.repository_owner == 'cryostatio' }}
-    steps:
-    - name: Fail if safe-to-test is not applied
-      if: (!contains(github.event.pull_request.labels.*.name, 'safe-to-test'))
-      run: exit 1
-
   build-agent:
     runs-on: ubuntu-latest
     needs: [check-before-build]
+    if: ${{ github.repository_owner == 'cryostatio' }}
     outputs: 
       image-version: ${{ steps.get-agent-version.outputs.agent-version }}
     steps:
@@ -94,6 +87,7 @@ jobs:
         submodules: true
         fetch-depth: 0
     - name: Build application
+      working-directory: quarkus-agent
       run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.agent-version }} clean verify
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -104,6 +98,7 @@ jobs:
         image: ${{ env.CI_IMG }}
         archs: amd64
         tags: ${{ env.agent-version }} ${{env.DATE_TAG}}
+        context: quarkus-agent
         containerfiles: |
           ./quarkus-agent/src/main/docker/Dockerfile.jvm
     - name: Push to quay.io
@@ -115,26 +110,5 @@ jobs:
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
         password: ${{ secrets.REPOSITORY_TOKEN }}
-    - name: store quarkus-agent image as output
-      id: quarkus-agent-image
-      run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> $GITHUB_OUTPUT
-
-  comment-image:
-    runs-on: ubuntu-latest
-    needs: [build-quarkus-test-app]
-    env:
-      image: ${{ needs.build-quarkus-test-app.outputs.quay-image }}
-    permissions:
-      pull-requests: write
-    steps:
-    - name: Create markdown table
-      id: md-table
-      uses: petems/csv-to-md-table-action@v4.0.0
-      with:
-        csvinput: |
-          ARCH, IMAGE
-          amd64, ${{ env.image }}
-    - uses: thollander/actions-comment-pull-request@v2
-      with:
-        message: |-
-          ${{ steps.md-table.outputs.markdown-table }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -15,9 +15,9 @@ on:
 env:
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
   OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
-  CI_USER: cryostat+bot
-  CI_REGISTRY: quay.io/cryostat
-  CI_IMG: quay.io/cryostat/quarkus-test
+  CI_USER: redhat-java-monitoring+github_ci
+  CI_REGISTRY: quay.io/redhat-java-monitoring
+  CI_IMG: quay.io/redhat-java-monitoring/quarkus-cryostat-agent
 
 jobs:
   check-before-build:
@@ -111,7 +111,7 @@ jobs:
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
-        password: ${{ secrets.REPOSITORY_PASSWORD }}
+        password: ${{ secrets.REPOSITORY_TOKEN }}
     - name: store quarkus-test image as output
       id: quarkus-test-image
       run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> $GITHUB_OUTPUT

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -86,7 +86,7 @@ jobs:
         cache: 'maven'
     - uses: actions/checkout@v4
       with:
-        repository: ${{ github.repository_owner }}/quarkus-test
+        repository: ${{ github.repository_owner }}/test-applications
         ref: main
         submodules: true
         fetch-depth: 0
@@ -107,7 +107,7 @@ jobs:
         archs: amd64
         tags: ${{ env.agent-version }}
         containerfiles: |
-          ./src/main/docker/Dockerfile.jvm
+          ./quarkus-test/src/main/docker/Dockerfile.jvm
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -90,11 +90,6 @@ jobs:
         ref: main
         submodules: true
         fetch-depth: 0
-    - name: maven-settings
-      uses: s4u/maven-settings-action@v2
-      with:
-        servers: '[{"id": "github", "username": "dummy", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
-        githubServer: false
     - name: Build application
       run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.agent-version }} clean verify
       env:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -102,18 +102,18 @@ jobs:
         archs: amd64
         tags: ${{ env.agent-version }}
         containerfiles: |
-          ./quarkus-test/src/main/docker/Dockerfile.jvm
+          ./quarkus-agent/src/main/docker/Dockerfile.jvm
     - name: Push to quay.io
       id: push-to-quay
       uses: redhat-actions/push-to-registry@v2
       with:
-        image: quarkus-test
+        image: quarkus-cryostat-agent
         tags: ${{ steps.buildah-build.outputs.tags }}
         registry: ${{ env.CI_REGISTRY }}
         username: ${{ env.CI_USER }}
         password: ${{ secrets.REPOSITORY_TOKEN }}
-    - name: store quarkus-test image as output
-      id: quarkus-test-image
+    - name: store quarkus-agent image as output
+      id: quarkus-agent-image
       run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> $GITHUB_OUTPUT
 
   comment-image:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -52,7 +52,7 @@ jobs:
     - id: get-agent-version
       run: |
         echo "agent-version=$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)" >> $GITHUB_OUTPUT
-    - uses: actions/setup-java@v3
+    - uses: actions/setup-java@v4
       with:
         java-version: '17'
         distribution: 'temurin'
@@ -74,7 +74,7 @@ jobs:
       pull-requests: write
       statuses: write
     outputs:
-      quay-image: ${{ steps.quakus-test-image.outputs.image }}
+      quay-image: ${{ steps.quarkus-test-image.outputs.image }}
     env:
       agent-version: ${{ needs.build-agent.outputs.image-version }}
     name: Build Java ${{ matrix.java }}
@@ -163,7 +163,7 @@ jobs:
     steps:
     - name: Create markdown table
       id: md-table
-      uses: petems/csv-to-md-table-action@v3.0.0
+      uses: petems/csv-to-md-table-action@v4.0.0
       with:
         csvinput: |
           ARCH, IMAGE

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -1,0 +1,109 @@
+name: Build Container Image
+
+concurrency:
+  group: ci-${{ github.run_id }}
+  cancel-in-progress: true
+
+on:
+  push:
+    branches:
+      - main
+      - v[0-9]+
+      - v[0-9]+.[0-9]+
+      - cryostat-v[0-9]+.[0-9]+
+
+env:
+  OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04/Release.key"
+  OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL: "https://download.opensuse.org/repositories/devel:/kubic:/libcontainers:/unstable/xUbuntu_22.04"
+  CI_USER: cryostat+bot
+  CI_REGISTRY: quay.io/cryostat
+  CI_IMG: quay.io/cryostat/quarkus-test
+
+jobs:
+  get-pom-properties:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
+    - id: query-pom
+      name: Get properties from POM
+      # Query POM image version and save as output parameter
+      run: |
+        IMAGE_VERSION="$(mvn -q -DforceStdout help:evaluate -Dexpression=project.version)"
+        echo "::set-output name=image-version::$IMAGE_VERSION"
+    outputs:
+      image-version: ${{ steps.query-pom.outputs.image-version }}
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    needs: [get-pom-properties]
+    strategy:
+      matrix:
+        java: ['17']
+    env:
+      IMAGE_VERSION: ${{ needs.get-pom-properties.outputs.image-version }}
+      cache-name: cache-yarn
+    name: Build and test Java ${{ matrix.java }}
+    permissions:
+      packages: write
+      contents: read
+    if: ${{ github.repository_owner == 'cryostatio' }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: true
+        fetch-depth: 0
+    - uses: actions/setup-java@v3
+      with:
+        java-version: ${{ matrix.java }}
+        distribution: 'temurin'
+        cache: 'maven'clear
+        
+    - name: Install podman v4
+      run: |
+        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
+        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
+        sudo apt -y purge podman
+        sudo apt update && sudo apt -y install podman
+    - name: Emulate docker with podman
+      run: |
+        mkdir -p $HOME/.bin
+        cat <(echo '#!/usr/bin/env bash') <(echo 'exec podman "$@"') > $HOME/.bin/docker
+        chmod +x $HOME/.bin/docker
+        echo "PATH=$HOME/.bin:$PATH" >> "$GITHUB_ENV"
+    - name: Set up testcontainers for podman
+      run: |
+        echo ryuk.container.privileged=true > ~/.testcontainers.properties
+        echo docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy >> ~/.testcontainers.properties
+        echo testcontainers.reuse.enable=false >> ~/.testcontainers.properties
+    - name: Start Podman API
+      run: systemctl --user enable --now podman.socket
+    - name: Set DOCKER_HOST environment variable
+      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
+    - name: Build application
+      run: ./mvnw -B -U clean verify
+    - name: Delete local integration test image
+      run: podman rmi ${{ env.CI_IMG }}:dev ${{ env.CI_IMG }}:${{ env.IMAGE_VERSION }}
+      continue-on-error: true
+    - name: Build container images and manifest
+      id: buildah-build
+      uses: redhat-actions/buildah-build@v2
+      with:
+        image: ${{ env.CI_IMG }}
+        archs: amd64, arm64
+        tags: ${{ env.IMAGE_VERSION }}
+        containerfiles: |
+          ./src/main/docker/Dockerfile.jvm
+    - name: Push to quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: cryostat
+        tags: ${{ steps.buildah-build.outputs.tags }}
+        registry: ${{ env.CI_REGISTRY }}
+        username: ${{ env.CI_USER }}
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+    - name: Print image URL
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -95,27 +95,6 @@ jobs:
       with:
         servers: '[{"id": "github", "username": "dummy", "password": "${{ secrets.GITHUB_TOKEN }}"}]'
         githubServer: false
-    - name: Install podman v4
-      run: |
-        echo "deb $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_SOURCE_URL/ /" | sudo tee /etc/apt/sources.list.d/devel:kubic:libcontainers:unstable.list
-        curl -fsSL $OPENSUSE_UNOFFICIAL_LIBCONTAINERS_KEY_URL | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/devel_kubic_libcontainers_unstable.gpg > /dev/null
-        sudo apt -y purge podman
-        sudo apt update && sudo apt -y install podman
-    - name: Emulate docker with podman
-      run: |
-        mkdir -p $HOME/.bin
-        cat <(echo '#!/usr/bin/env bash') <(echo 'exec podman "$@"') > $HOME/.bin/docker
-        chmod +x $HOME/.bin/docker
-        echo "PATH=$HOME/.bin:$PATH" >> "$GITHUB_ENV"
-    - name: Set up testcontainers for podman
-      run: |
-        echo ryuk.container.privileged=true > ~/.testcontainers.properties
-        echo docker.client.strategy=org.testcontainers.dockerclient.UnixSocketClientProviderStrategy >> ~/.testcontainers.properties
-        echo testcontainers.reuse.enable=false >> ~/.testcontainers.properties
-    - name: Start Podman API
-      run: systemctl --user enable --now podman.socket
-    - name: Set DOCKER_HOST environment variable
-      run: echo "DOCKER_HOST=unix:///run/user/$(id -u)/podman/podman.sock" >> "$GITHUB_ENV"
     - name: Build application
       run: ./mvnw -B -U -Dio.cryostat.agent.version=${{ env.agent-version }} clean verify
       env:

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main
@@ -72,6 +73,8 @@ jobs:
       with:
         submodules: true
         fetch-depth: 0
+    - name: Get date tag
+      run: echo "DATE_TAG=$(date -uI)" >> "$GITHUB_ENV"
     - uses: actions/cache@v4
       with:
         path: ~/.m2
@@ -100,7 +103,7 @@ jobs:
       with:
         image: ${{ env.CI_IMG }}
         archs: amd64
-        tags: ${{ env.agent-version }}
+        tags: ${{ env.agent-version }} ${{env.DATE_TAG}}
         containerfiles: |
           ./quarkus-agent/src/main/docker/Dockerfile.jvm
     - name: Push to quay.io

--- a/.github/workflows/container-image.yml
+++ b/.github/workflows/container-image.yml
@@ -151,7 +151,7 @@ jobs:
         password: ${{ secrets.QUAY_PASSWORD }}
     - name: store quarkus-test image as output
       id: quarkus-test-image
-      run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> "$GITHUB_OUTPUT"
+      run: echo "image=${{ steps.push-to-quay.outputs.registry-path }}" >> $GITHUB_OUTPUT
 
   comment-image:
     runs-on: ubuntu-latest


### PR DESCRIPTION
related to: https://github.com/cryostatio/cryostat-operator/issues/791

This CI workflow builds the agent image, then packages it in the quarkus-test sample application and pushes it to the crysotat quay repo. 

example workflow in my forked -agent repo: https://github.com/mwangggg/cryostat-agent/actions/runs/8974812712