### PR TITLE
feat(auth): apply auth map fn on every request

### DIFF
--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -33,6 +33,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -201,12 +202,12 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_AUTHORIZATION)
-    public static Optional<String> provideCryostatAgentAuthorization(
+    public static Supplier<Optional<String>> provideCryostatAgentAuthorization(
             Config config,
             AuthorizationType authorizationType,
             @Named(CRYOSTAT_AGENT_AUTHORIZATION_VALUE) Optional<String> authorizationValue) {
         Optional<String> opt = config.getOptionalValue(CRYOSTAT_AGENT_AUTHORIZATION, String.class);
-        return opt.or(() -> authorizationValue.map(authorizationType::apply));
+        return () -> opt.or(() -> authorizationValue.map(authorizationType::apply));
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -313,6 +313,8 @@ public abstract class ConfigModule {
         return truststoreConfigs;
     }
 
+    @Provides
+    @Singleton
     @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT)
     public static int provideCryostatAgentWebclientResponseRetryCount(Config config) {
         return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT, int.class);

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -313,7 +313,7 @@ public abstract class ConfigModule {
         return truststoreConfigs;
     }
 
-    @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS)
+    @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT)
     public static int provideCryostatAgentWebclientResponseRetryCount(Config config) {
         return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT, int.class);
     }

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -82,6 +82,8 @@ public abstract class ConfigModule {
     public static final Pattern CRYOSTAT_AGENT_TRUSTSTORE_PATTERN =
             Pattern.compile(
                     "^(?:cryostat\\.agent\\.webclient\\.tls\\.truststore\\.cert)\\[(?<index>\\d+)\\]\\.(?<property>.*)$");
+    public static final String CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT =
+            "cryostat.agent.webclient.response.retry-count";
 
     public static final String CRYOSTAT_AGENT_WEBSERVER_HOST = "cryostat.agent.webserver.host";
     public static final String CRYOSTAT_AGENT_WEBSERVER_PORT = "cryostat.agent.webserver.port";
@@ -309,6 +311,11 @@ public abstract class ConfigModule {
             }
         }
         return truststoreConfigs;
+    }
+
+    @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS)
+    public static int provideCryostatAgentWebclientResponseRetryCount(Config config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT, int.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import io.cryostat.agent.FlightRecorderHelper.ConfigurationInfo;
 import io.cryostat.agent.FlightRecorderHelper.TemplatedRecording;
@@ -80,6 +81,7 @@ public class CryostatClient {
     private final Executor executor;
     private final ObjectMapper mapper;
     private final HttpClient http;
+    private final Supplier<Optional<String>> authorizationSupplier;
 
     private final String appName;
     private final String instanceId;
@@ -91,6 +93,7 @@ public class CryostatClient {
             Executor executor,
             ObjectMapper mapper,
             HttpClient http,
+            Supplier<Optional<String>> authorizationSupplier,
             String instanceId,
             String jvmId,
             String appName,
@@ -99,6 +102,7 @@ public class CryostatClient {
         this.executor = executor;
         this.mapper = mapper;
         this.http = http;
+        this.authorizationSupplier = authorizationSupplier;
         this.instanceId = instanceId;
         this.jvmId = jvmId;
         this.appName = appName;
@@ -450,6 +454,7 @@ public class CryostatClient {
     }
 
     private <T> CompletableFuture<T> supply(HttpRequestBase req, Function<HttpResponse, T> fn) {
+        authorizationSupplier.get().ifPresent(v -> req.addHeader("Authorization", v));
         return CompletableFuture.supplyAsync(() -> fn.apply(executeQuiet(req)), executor)
                 .whenComplete((v, t) -> req.reset());
     }

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -454,6 +454,11 @@ public class CryostatClient {
     }
 
     private <T> CompletableFuture<T> supply(HttpRequestBase req, Function<HttpResponse, T> fn) {
+        // FIXME Apache httpclient 4 does not support Bearer token auth easily, so we explicitly set
+        // the header here. This is a form of preemptive auth - the token is always sent with the
+        // request. It would be better to attempt to send the request to the server first and see if
+        // it responds with an auth challenge, and then send the auth information we have, and use
+        // the client auth cache. This flow is supported for Bearer tokens in httpclient 5.
         authorizationSupplier.get().ifPresent(v -> req.addHeader("Authorization", v));
         return CompletableFuture.supplyAsync(() -> fn.apply(executeQuiet(req)), executor)
                 .whenComplete((v, t) -> req.reset());

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -459,7 +459,7 @@ public class CryostatClient {
         // request. It would be better to attempt to send the request to the server first and see if
         // it responds with an auth challenge, and then send the auth information we have, and use
         // the client auth cache. This flow is supported for Bearer tokens in httpclient 5.
-        authorizationSupplier.get().ifPresent(v -> req.addHeader("Authorization", v));
+        authorizationSupplier.get().ifPresent(v -> req.addHeader(HttpHeaders.AUTHORIZATION, v));
         return CompletableFuture.supplyAsync(() -> fn.apply(executeQuiet(req)), executor)
                 .whenComplete((v, t) -> req.reset());
     }

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -70,6 +70,7 @@ import org.apache.http.client.HttpClient;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.client.HttpClients;
+import org.apache.http.impl.client.StandardHttpRequestRetryHandler;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -333,7 +334,8 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_TLS_VERIFY_HOSTNAME)
                     boolean verifyHostname,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_CONNECT_TIMEOUT_MS) int connectTimeout,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) int responseTimeout) {
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) int responseTimeout,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT) int retryCount) {
         HttpClientBuilder builder =
                 HttpClients.custom()
                         .setSSLContext(sslContext)
@@ -344,7 +346,8 @@ public abstract class MainModule {
                                         .setConnectTimeout(connectTimeout)
                                         .setSocketTimeout(responseTimeout)
                                         .setRedirectsEnabled(true)
-                                        .build());
+                                        .build())
+                        .setRetryHandler(new StandardHttpRequestRetryHandler(retryCount, true));
 
         if (!verifyHostname) {
             builder = builder.setSSLHostnameVerifier((hostname, session) -> true);

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -343,6 +343,7 @@ public abstract class MainModule {
                                         .setExpectContinueEnabled(true)
                                         .setConnectTimeout(connectTimeout)
                                         .setSocketTimeout(responseTimeout)
+                                        .setRedirectsEnabled(true)
                                         .build());
 
         if (!verifyHostname) {

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -9,6 +9,7 @@ cryostat.agent.webclient.tls.trust-all=false
 cryostat.agent.webclient.tls.verify-hostname=true
 cryostat.agent.webclient.connect.timeout-ms=1000
 cryostat.agent.webclient.response.timeout-ms=1000
+cryostat.agent.webclient.response.retry-count=3
 cryostat.agent.webserver.host=0.0.0.0
 cryostat.agent.webserver.port=9977
 cryostat.agent.webserver.tls.version=${cryostat.agent.webclient.tls.version}


### PR DESCRIPTION
For file-read-based authorization, ie kubernetes serviceaccount token, this results in the most up-to-date value being used for HTTP client Authorization headers with each request

Fixes #428
