### PR TITLE
ci(release): add action for manually triggering Maven Central releases

### DIFF
--- a/.github/workflows/maven-central-release.yml
+++ b/.github/workflows/maven-central-release.yml
@@ -1,0 +1,12 @@
+# Inspired from https://foojay.io/today/how-to-release-a-java-module-with-jreleaser-to-maven-central-with-github-actions/
+name: Publish a new Maven Central release
+
+on:
+  workflow_dispatch:
+
+jobs:
+  publish-release:
+    uses: ./.github/workflows/maven-central-publish.yml
+    secrets: inherit
+    with:
+      publish-cmd: './release.sh'


### PR DESCRIPTION
Since https://github.com/cryostatio/cryostat-agent/pull/455 , the workflow is no longer manually callable for publishing releases to Maven Central. This attempts to re-enable that feature, so that snapshot builds get published automatically and release builds can be published with our documented manual workflow.