### PR TITLE
feat(versions): record own build info/version as properties, validate server version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,8 +104,12 @@
   <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
   <maven-javadoc-plugin.version>3.10.1</maven-javadoc-plugin.version>
   <jreleaser-maven-plugin.version>1.14.0</jreleaser-maven-plugin.version>
+  <org.codehaus.mojo.exec.plugin.version>3.4.1</org.codehaus.mojo.exec.plugin.version>
 
   <shade.prefix>io.cryostat.agent.shaded</shade.prefix>
+
+  <cryostat.server.version.min>4.0.0</cryostat.server.version.min>
+  <cryostat.server.version.max>5.0.0</cryostat.server.version.max>
 </properties>
 
 <dependencyManagement>
@@ -298,6 +302,29 @@
           </manifestEntries>
         </archive>
       </configuration>
+    </plugin>
+    <plugin>
+      <groupId>org.codehaus.mojo</groupId>
+      <artifactId>exec-maven-plugin</artifactId>
+      <version>${org.codehaus.mojo.exec.plugin.version}</version>
+      <executions>
+        <execution>
+          <id>generate-git-version</id>
+          <phase>generate-resources</phase>
+          <goals>
+            <goal>exec</goal>
+          </goals>
+          <configuration>
+            <executable>git</executable>
+            <arguments>
+              <argument>rev-parse</argument>
+              <argument>--verify</argument>
+              <argument>HEAD</argument>
+            </arguments>
+            <outputFile>${project.build.directory}/classes/META-INF/gitinfo</outputFile>
+          </configuration>
+        </execution>
+      </executions>
     </plugin>
     <plugin>
       <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -204,7 +204,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
         Map<String, String> properties = new HashMap<>();
         properties.putAll(args.getProperties());
         properties.put("build.git.commit-hash", new BuildInfo().getGitInfo().getHash());
-        String agentVersion = "unknown";
+        Semver agentVersion = Semver.UNKNOWN;
         Pair<Semver, Semver> serverVersionRange = Pair.of(Semver.UNKNOWN, Semver.UNKNOWN);
         try {
             VersionInfo versionInfo = VersionInfo.load();

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -155,7 +155,6 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
         Thread t =
                 new Thread(
                         () -> {
-                            log.info("Cryostat Agent starting...");
                             agent.accept(aa);
                         });
         t.setDaemon(true);
@@ -211,6 +210,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
         } catch (IOException ioe) {
             log.warn("Unable to read versions.properties file", ioe);
         }
+        log.info("Cryostat Agent version {} starting...", agentVersion);
         properties.forEach(
                 (k, v) -> {
                     log.trace("Set system property {} = {}", k, v);
@@ -281,7 +281,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
             webServer.start();
             registration.start();
             client.triggerEvaluator().start(args.getSmartTriggers());
-            log.info("Cryostat Agent {} startup complete", agentVersion);
+            log.info("startup complete");
         } catch (Exception e) {
             log.error(Agent.class.getSimpleName() + " startup failure", e);
             if (agentExitHandler != null) {

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -202,10 +202,11 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
     public void accept(AgentArgs args) {
         Map<String, String> properties = new HashMap<>();
         properties.putAll(args.getProperties());
-        properties.put("gitCommitHash", new BuildInfo().getGitInfo().getHash());
+        properties.put("build.git.commit-hash", new BuildInfo().getGitInfo().getHash());
         String agentVersion = "unknown";
         try {
             VersionInfo versionInfo = VersionInfo.load();
+            agentVersion = versionInfo.getAgentVersion();
             properties.putAll(versionInfo.asMap());
         } catch (IOException ioe) {
             log.warn("Unable to read versions.properties file", ioe);

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -281,7 +281,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
             webServer.start();
             registration.start();
             client.triggerEvaluator().start(args.getSmartTriggers());
-            log.info("startup complete");
+            log.info("Startup complete");
         } catch (Exception e) {
             log.error(Agent.class.getSimpleName() + " startup failure", e);
             if (agentExitHandler != null) {

--- a/src/main/java/io/cryostat/agent/BuildInfo.java
+++ b/src/main/java/io/cryostat/agent/BuildInfo.java
@@ -19,6 +19,8 @@ import java.io.BufferedReader;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
 
+import io.cryostat.agent.util.ResourcesUtil;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,9 +41,7 @@ public class BuildInfo {
             try (BufferedReader br =
                     new BufferedReader(
                             new InputStreamReader(
-                                    Thread.currentThread()
-                                            .getContextClassLoader()
-                                            .getResourceAsStream(RESOURCE_LOCATION),
+                                    ResourcesUtil.getResourceAsStream(RESOURCE_LOCATION),
                                     StandardCharsets.UTF_8))) {
                 return br.lines()
                         .findFirst()

--- a/src/main/java/io/cryostat/agent/BuildInfo.java
+++ b/src/main/java/io/cryostat/agent/BuildInfo.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+// FIXME this is adapted from Cryostat. Extract this to a reusable utility in libcryostat?
+public class BuildInfo {
+
+    private static Logger log = LoggerFactory.getLogger(BuildInfo.class);
+    private static final String RESOURCE_LOCATION = "META-INF/gitinfo";
+
+    private final GitInfo gitinfo = new GitInfo();
+
+    public GitInfo getGitInfo() {
+        return gitinfo;
+    }
+
+    public static class GitInfo {
+        public String getHash() {
+            try (BufferedReader br =
+                    new BufferedReader(
+                            new InputStreamReader(
+                                    Thread.currentThread()
+                                            .getContextClassLoader()
+                                            .getResourceAsStream(RESOURCE_LOCATION),
+                                    StandardCharsets.UTF_8))) {
+                return br.lines()
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalStateException(
+                                                String.format(
+                                                        "Resource file %s is empty",
+                                                        RESOURCE_LOCATION)))
+                        .trim();
+            } catch (Exception e) {
+                log.warn("Version retrieval exception", e);
+                return "unknown";
+            }
+        }
+    }
+}

--- a/src/main/java/io/cryostat/agent/VersionInfo.java
+++ b/src/main/java/io/cryostat/agent/VersionInfo.java
@@ -22,6 +22,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 
+import io.cryostat.agent.util.ResourcesUtil;
+
 public class VersionInfo {
 
     private static final String RESOURCE_LOCATION = "versions.properties";
@@ -42,10 +44,7 @@ public class VersionInfo {
 
     public static VersionInfo load() throws IOException {
         Properties prop = new Properties();
-        try (InputStream is =
-                Thread.currentThread()
-                        .getContextClassLoader()
-                        .getResourceAsStream(RESOURCE_LOCATION)) {
+        try (InputStream is = ResourcesUtil.getResourceAsStream(RESOURCE_LOCATION)) {
             prop.load(is);
         }
         String agentVersion = prop.getProperty(AGENT_VERSION_KEY);
@@ -80,6 +79,8 @@ public class VersionInfo {
     }
 
     public static class Semver implements Comparable<Semver> {
+
+        public static final Semver UNKNOWN = new Semver(0, 0, 0);
 
         private final int major;
         private final int minor;

--- a/src/main/java/io/cryostat/agent/VersionInfo.java
+++ b/src/main/java/io/cryostat/agent/VersionInfo.java
@@ -31,12 +31,12 @@ public class VersionInfo {
     static final String MIN_VERSION_KEY = "cryostat.server.version.min";
     static final String MAX_VERSION_KEY = "cryostat.server.version.max";
 
-    private final String agentVersion;
+    private final Semver agentVersion;
     private final Semver serverMin;
     private final Semver serverMax;
 
     // testing only
-    VersionInfo(String agentVersion, Semver serverMin, Semver serverMax) {
+    VersionInfo(Semver agentVersion, Semver serverMin, Semver serverMax) {
         this.agentVersion = agentVersion;
         this.serverMin = serverMin;
         this.serverMax = serverMax;
@@ -47,7 +47,7 @@ public class VersionInfo {
         try (InputStream is = ResourcesUtil.getResourceAsStream(RESOURCE_LOCATION)) {
             prop.load(is);
         }
-        String agentVersion = prop.getProperty(AGENT_VERSION_KEY);
+        Semver agentVersion = Semver.fromString(prop.getProperty(AGENT_VERSION_KEY));
         Semver serverMin = Semver.fromString(prop.getProperty(MIN_VERSION_KEY));
         Semver serverMax = Semver.fromString(prop.getProperty(MAX_VERSION_KEY));
         return new VersionInfo(agentVersion, serverMin, serverMax);
@@ -55,12 +55,12 @@ public class VersionInfo {
 
     public Map<String, String> asMap() {
         return Map.of(
-                AGENT_VERSION_KEY, getAgentVersion(),
+                AGENT_VERSION_KEY, getAgentVersion().toString(),
                 MIN_VERSION_KEY, getServerMin().toString(),
                 MAX_VERSION_KEY, getServerMax().toString());
     }
 
-    public String getAgentVersion() {
+    public Semver getAgentVersion() {
         return agentVersion;
     }
 
@@ -80,7 +80,13 @@ public class VersionInfo {
 
     public static class Semver implements Comparable<Semver> {
 
-        public static final Semver UNKNOWN = new Semver(0, 0, 0);
+        public static final Semver UNKNOWN =
+                new Semver(0, 0, 0) {
+                    @Override
+                    public String toString() {
+                        return "unknown";
+                    }
+                };
 
         private final int major;
         private final int minor;

--- a/src/main/java/io/cryostat/agent/VersionInfo.java
+++ b/src/main/java/io/cryostat/agent/VersionInfo.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Comparator;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
+
+public class VersionInfo {
+
+    private static final String RESOURCE_LOCATION = "versions.properties";
+    static final String AGENT_VERSION_KEY = "cryostat.agent.version";
+    static final String MIN_VERSION_KEY = "cryostat.server.version.min";
+    static final String MAX_VERSION_KEY = "cryostat.server.version.max";
+
+    private final String agentVersion;
+    private final Semver serverMin;
+    private final Semver serverMax;
+
+    // testing only
+    VersionInfo(String agentVersion, Semver serverMin, Semver serverMax) {
+        this.agentVersion = agentVersion;
+        this.serverMin = serverMin;
+        this.serverMax = serverMax;
+    }
+
+    public static VersionInfo load() throws IOException {
+        Properties prop = new Properties();
+        try (InputStream is =
+                Thread.currentThread()
+                        .getContextClassLoader()
+                        .getResourceAsStream(RESOURCE_LOCATION)) {
+            prop.load(is);
+        }
+        String agentVersion = prop.getProperty(AGENT_VERSION_KEY);
+        Semver serverMin = Semver.fromString(prop.getProperty(MIN_VERSION_KEY));
+        Semver serverMax = Semver.fromString(prop.getProperty(MAX_VERSION_KEY));
+        return new VersionInfo(agentVersion, serverMin, serverMax);
+    }
+
+    public Map<String, String> asMap() {
+        return Map.of(
+                AGENT_VERSION_KEY, getAgentVersion(),
+                MIN_VERSION_KEY, getServerMin().toString(),
+                MAX_VERSION_KEY, getServerMax().toString());
+    }
+
+    public String getAgentVersion() {
+        return agentVersion;
+    }
+
+    public Semver getServerMin() {
+        return serverMin;
+    }
+
+    public Semver getServerMax() {
+        return serverMax;
+    }
+
+    public boolean validateServerVersion(Semver actual) {
+        boolean greaterEqualMin = getServerMin().compareTo(actual) <= 0;
+        boolean lesserMax = getServerMax().compareTo(actual) > 0;
+        return greaterEqualMin && lesserMax;
+    }
+
+    public static class Semver implements Comparable<Semver> {
+
+        private final int major;
+        private final int minor;
+        private final int patch;
+
+        public Semver(int major, int minor, int patch) {
+            this.major = major;
+            this.minor = minor;
+            this.patch = patch;
+        }
+
+        public static Semver fromString(String in) {
+            String[] parts = in.split("\\.");
+            if (parts.length != 3) {
+                throw new IllegalArgumentException();
+            }
+            return new Semver(
+                    Integer.parseInt(parts[0]),
+                    Integer.parseInt(parts[1]),
+                    Integer.parseInt(parts[2]));
+        }
+
+        public int getMajor() {
+            return major;
+        }
+
+        public int getMinor() {
+            return minor;
+        }
+
+        public int getPatch() {
+            return patch;
+        }
+
+        @Override
+        public String toString() {
+            return String.format("%d.%d.%d", major, minor, patch);
+        }
+
+        @Override
+        public int compareTo(Semver o) {
+            return Comparator.comparingInt(Semver::getMajor)
+                    .thenComparing(Semver::getMinor)
+                    .thenComparing(Semver::getPatch)
+                    .compare(this, o);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(major, minor, patch);
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj) {
+                return true;
+            }
+            if (obj == null) {
+                return false;
+            }
+            if (getClass() != obj.getClass()) {
+                return false;
+            }
+            Semver other = (Semver) obj;
+            return major == other.major && minor == other.minor && patch == other.patch;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/agent/model/ServerHealth.java
+++ b/src/main/java/io/cryostat/agent/model/ServerHealth.java
@@ -20,6 +20,9 @@ import java.util.regex.Pattern;
 
 import io.cryostat.agent.VersionInfo.Semver;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+@SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class ServerHealth {
 
     private static final Pattern VERSION_PATTERN =
@@ -64,6 +67,7 @@ public class ServerHealth {
         return build;
     }
 
+    @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public static class BuildInfo {
         private GitInfo git;
 
@@ -82,6 +86,7 @@ public class ServerHealth {
         }
     }
 
+    @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
     public static class GitInfo {
         private String hash;
 

--- a/src/main/java/io/cryostat/agent/model/ServerHealth.java
+++ b/src/main/java/io/cryostat/agent/model/ServerHealth.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.model;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import io.cryostat.agent.VersionInfo.Semver;
+
+public class ServerHealth {
+
+    private static final Pattern VERSION_PATTERN =
+            Pattern.compile(
+                    "^v(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?:-[a-z0-9\\._-]*)?",
+                    Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+
+    private String cryostatVersion;
+    private BuildInfo build;
+
+    public ServerHealth() {}
+
+    public ServerHealth(String cryostatVersion, BuildInfo build) {
+        this.cryostatVersion = cryostatVersion;
+        this.build = build;
+    }
+
+    public void setCryostatVersion(String cryostatVersion) {
+        this.cryostatVersion = cryostatVersion;
+    }
+
+    public void setBuild(BuildInfo build) {
+        this.build = build;
+    }
+
+    public String cryostatVersion() {
+        return cryostatVersion;
+    }
+
+    public Semver cryostatSemver() {
+        Matcher m = VERSION_PATTERN.matcher(cryostatVersion());
+        if (!m.matches()) {
+            return Semver.fromString("0.0.0");
+        }
+        return new Semver(
+                Integer.parseInt(m.group("major")),
+                Integer.parseInt(m.group("minor")),
+                Integer.parseInt(m.group("patch")));
+    }
+
+    public BuildInfo buildInfo() {
+        return build;
+    }
+
+    public static class BuildInfo {
+        private GitInfo git;
+
+        public BuildInfo() {}
+
+        public BuildInfo(GitInfo git) {
+            this.git = git;
+        }
+
+        public void setGit(GitInfo git) {
+            this.git = git;
+        }
+
+        public GitInfo git() {
+            return git;
+        }
+    }
+
+    public static class GitInfo {
+        private String hash;
+
+        public GitInfo() {}
+
+        public GitInfo(String hash) {
+            this.hash = hash;
+        }
+
+        public void setHash(String hash) {
+            this.hash = hash;
+        }
+
+        public String hash() {
+            return hash;
+        }
+    }
+}

--- a/src/main/java/io/cryostat/agent/util/ResourcesUtil.java
+++ b/src/main/java/io/cryostat/agent/util/ResourcesUtil.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.util;
+
+import java.io.InputStream;
+
+public class ResourcesUtil {
+
+    private ResourcesUtil() {}
+
+    public static ClassLoader getClassLoader() {
+        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        if (cl == null) {
+            cl = ClassLoader.getSystemClassLoader();
+        }
+        return cl;
+    }
+
+    public static InputStream getResourceAsStream(String location) {
+        return getClassLoader().getResourceAsStream(location);
+    }
+}

--- a/src/main/resources/versions.properties
+++ b/src/main/resources/versions.properties
@@ -1,0 +1,3 @@
+cryostat.agent.version=${version}
+cryostat.server.version.min=${cryostat.server.version.min}
+cryostat.server.version.max=${cryostat.server.version.max}

--- a/src/test/java/io/cryostat/agent/SemverTest.java
+++ b/src/test/java/io/cryostat/agent/SemverTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+import io.cryostat.agent.VersionInfo.Semver;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class SemverTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "1.0.0, 1.0.0, 0",
+        "2.0.0, 1.0.0, 1",
+        "1.0.0, 2.0.0, -1",
+        "1.0.0, 1.1.0, -1",
+        "1.1.0, 1.0.0, 1",
+        "1.0.1, 1.0.0, 1",
+        "2.0.0, 1.1.0, 1",
+        "1.0.1, 1.1.0, -1",
+        "1.1.1, 1.0.1, 1",
+    })
+    public void test(String first, String second, int result) {
+        Semver a = Semver.fromString(first);
+        Semver b = Semver.fromString(second);
+        MatcherAssert.assertThat(a.compareTo(b), Matchers.equalTo(result));
+    }
+}

--- a/src/test/java/io/cryostat/agent/VersionInfoTest.java
+++ b/src/test/java/io/cryostat/agent/VersionInfoTest.java
@@ -17,46 +17,21 @@ package io.cryostat.agent;
 
 import io.cryostat.agent.VersionInfo.Semver;
 
-import org.junit.jupiter.api.Assertions;
-import org.junit.jupiter.api.Test;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 public class VersionInfoTest {
 
     static final Semver serverMin = Semver.fromString("1.0.0");
     static final Semver serverMax = Semver.fromString("2.0.0");
 
-    @Test
-    public void testActualEqualsMin() {
+    @ParameterizedTest
+    @CsvSource({"1.0.0, true", "2.0.0, false", "3.0.0, false", "0.1.0, false", "1.1.0, true"})
+    public void test(String serverVersion, boolean inRange) {
         VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
-        Semver actual = Semver.fromString("1.0.0");
-        Assertions.assertTrue(info.validateServerVersion(actual));
-    }
-
-    @Test
-    public void testActualEqualsMax() {
-        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
-        Semver actual = Semver.fromString("2.0.0");
-        Assertions.assertFalse(info.validateServerVersion(actual));
-    }
-
-    @Test
-    public void testActualGreaterMax() {
-        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
-        Semver actual = Semver.fromString("3.0.0");
-        Assertions.assertFalse(info.validateServerVersion(actual));
-    }
-
-    @Test
-    public void testActualLesserMin() {
-        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
-        Semver actual = Semver.fromString("0.1.0");
-        Assertions.assertFalse(info.validateServerVersion(actual));
-    }
-
-    @Test
-    public void testActualInRange() {
-        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
-        Semver actual = Semver.fromString("1.1.0");
-        Assertions.assertTrue(info.validateServerVersion(actual));
+        Semver actual = Semver.fromString(serverVersion);
+        MatcherAssert.assertThat(info.validateServerVersion(actual), Matchers.equalTo(inRange));
     }
 }

--- a/src/test/java/io/cryostat/agent/VersionInfoTest.java
+++ b/src/test/java/io/cryostat/agent/VersionInfoTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+import io.cryostat.agent.VersionInfo.Semver;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class VersionInfoTest {
+
+    static final Semver serverMin = Semver.fromString("1.0.0");
+    static final Semver serverMax = Semver.fromString("2.0.0");
+
+    @Test
+    public void testActualEqualsMin() {
+        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        Semver actual = Semver.fromString("1.0.0");
+        Assertions.assertTrue(info.validateServerVersion(actual));
+    }
+
+    @Test
+    public void testActualEqualsMax() {
+        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        Semver actual = Semver.fromString("2.0.0");
+        Assertions.assertFalse(info.validateServerVersion(actual));
+    }
+
+    @Test
+    public void testActualGreaterMax() {
+        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        Semver actual = Semver.fromString("3.0.0");
+        Assertions.assertFalse(info.validateServerVersion(actual));
+    }
+
+    @Test
+    public void testActualLesserMin() {
+        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        Semver actual = Semver.fromString("0.1.0");
+        Assertions.assertFalse(info.validateServerVersion(actual));
+    }
+
+    @Test
+    public void testActualInRange() {
+        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        Semver actual = Semver.fromString("1.1.0");
+        Assertions.assertTrue(info.validateServerVersion(actual));
+    }
+}

--- a/src/test/java/io/cryostat/agent/VersionInfoTest.java
+++ b/src/test/java/io/cryostat/agent/VersionInfoTest.java
@@ -27,35 +27,35 @@ public class VersionInfoTest {
 
     @Test
     public void testActualEqualsMin() {
-        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString("1.0.0");
         Assertions.assertTrue(info.validateServerVersion(actual));
     }
 
     @Test
     public void testActualEqualsMax() {
-        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString("2.0.0");
         Assertions.assertFalse(info.validateServerVersion(actual));
     }
 
     @Test
     public void testActualGreaterMax() {
-        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString("3.0.0");
         Assertions.assertFalse(info.validateServerVersion(actual));
     }
 
     @Test
     public void testActualLesserMin() {
-        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString("0.1.0");
         Assertions.assertFalse(info.validateServerVersion(actual));
     }
 
     @Test
     public void testActualInRange() {
-        VersionInfo info = new VersionInfo("", serverMin, serverMax);
+        VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString("1.1.0");
         Assertions.assertTrue(info.validateServerVersion(actual));
     }

--- a/src/test/java/io/cryostat/agent/model/ServerHealthTest.java
+++ b/src/test/java/io/cryostat/agent/model/ServerHealthTest.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.model;
+
+import io.cryostat.agent.VersionInfo.Semver;
+import io.cryostat.agent.model.ServerHealth.BuildInfo;
+import io.cryostat.agent.model.ServerHealth.GitInfo;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+public class ServerHealthTest {
+
+    @Test
+    public void test() {
+        GitInfo git = new GitInfo("abcd1234");
+        BuildInfo build = new BuildInfo(git);
+        ServerHealth health = new ServerHealth("v1.2.3-snapshot", build);
+        MatcherAssert.assertThat(
+                health.cryostatSemver(), Matchers.equalTo(Semver.fromString("1.2.3")));
+    }
+}


### PR DESCRIPTION
Fixes #504
Fixes #505

At build time, the following bits of information are recorded into resources files which are included in the distribution JAR:
- `pom.xml` `version`, ie the Agent's own version string
- `pom.xml` `cryostat.server.version.min` and `cryostat.server.version.max`, the minimum (inclusive) and maximum (exclusive) Cryostat server versions that this Agent version is expected to work with. Currently set to 4.0.0 and 5.0.0 respectively, forming the range `[4.0.0, 5.0.0)`, so that any Cryostat server version `4.y.z` should be within range. These are set as `pom.xml` properties rather than in the `microprofile-config.properties` so that they are build-time immutable.
- current git commit hash

The Agent reads its own version string and logs this at startup. It loads all of these values and sets them as various system properties so that they can be retrieved generically later on. Finally, when it attempts to register itself with the Cryostat server, it performs a `GET /health` check against the server to obtain the server's `cryostatVersion` string, then parses that to a semantic version, and compares that to the expected server version range. If the actual server version is outside of the expected range then the agent logs a warning.

```
2024-10-04 18:07:44:382 +0000 [cryostat-agent-main] INFO io.cryostat.agent.Agent - Cryostat Agent version 0.5.0-SNAPSHOT starting...
...
2024-10-04 18:08:25:018 +0000 [cryostat-agent-worker-2] DEBUG io.cryostat.agent.Registration - Connected to Cryostat server: version 4.0.0 , build abfc597f1a7ad93093f7ead616766d56b4333809
```

![Screenshot_2024-10-04_14-12-10](https://github.com/user-attachments/assets/3dc97c62-8f67-4fbf-9c82-97da2eb80593)
