### PR TITLE
fix(semver): handle unparseable version strings by returning UNKNOWN instead of throwing

### DIFF
--- a/src/main/java/io/cryostat/agent/VersionInfo.java
+++ b/src/main/java/io/cryostat/agent/VersionInfo.java
@@ -24,6 +24,9 @@ import java.util.Properties;
 
 import io.cryostat.agent.util.ResourcesUtil;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 public class VersionInfo {
 
     private static final String RESOURCE_LOCATION = "versions.properties";
@@ -80,6 +83,8 @@ public class VersionInfo {
 
     public static class Semver implements Comparable<Semver> {
 
+        private static Logger log = LoggerFactory.getLogger(Semver.class);
+
         public static final Semver UNKNOWN =
                 new Semver(0, 0, 0) {
                     @Override
@@ -103,10 +108,15 @@ public class VersionInfo {
             if (parts.length != 3) {
                 throw new IllegalArgumentException();
             }
-            return new Semver(
-                    Integer.parseInt(parts[0]),
-                    Integer.parseInt(parts[1]),
-                    Integer.parseInt(parts[2]));
+            try {
+                return new Semver(
+                        Integer.parseInt(parts[0]),
+                        Integer.parseInt(parts[1]),
+                        Integer.parseInt(parts[2]));
+            } catch (NumberFormatException nfe) {
+                log.error(String.format("Unable to parse input string \"%s\"", in), nfe);
+                return UNKNOWN;
+            }
         }
 
         public int getMajor() {

--- a/src/main/java/io/cryostat/agent/model/ServerHealth.java
+++ b/src/main/java/io/cryostat/agent/model/ServerHealth.java
@@ -15,20 +15,12 @@
  */
 package io.cryostat.agent.model;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
 import io.cryostat.agent.VersionInfo.Semver;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 
 @SuppressFBWarnings(value = {"EI_EXPOSE_REP", "EI_EXPOSE_REP2"})
 public class ServerHealth {
-
-    private static final Pattern VERSION_PATTERN =
-            Pattern.compile(
-                    "^v(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?:-[a-z0-9\\._-]*)?",
-                    Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
     private String cryostatVersion;
     private BuildInfo build;
@@ -53,14 +45,7 @@ public class ServerHealth {
     }
 
     public Semver cryostatSemver() {
-        Matcher m = VERSION_PATTERN.matcher(cryostatVersion());
-        if (!m.matches()) {
-            return Semver.fromString("0.0.0");
-        }
-        return new Semver(
-                Integer.parseInt(m.group("major")),
-                Integer.parseInt(m.group("minor")),
-                Integer.parseInt(m.group("patch")));
+        return Semver.fromString(cryostatVersion());
     }
 
     public BuildInfo buildInfo() {

--- a/src/test/java/io/cryostat/agent/SemverTest.java
+++ b/src/test/java/io/cryostat/agent/SemverTest.java
@@ -35,6 +35,9 @@ public class SemverTest {
         "2.0.0, 1.1.0, 1",
         "1.0.1, 1.1.0, -1",
         "1.1.1, 1.0.1, 1",
+        "1.0.0-SNAPSHOT, 1.0.0, 0",
+        "v1.0.0-SNAPSHOT, 1.0.0, 0",
+        "v1.0.0, 1.0.0, 0",
     })
     public void test(String first, String second, int result) {
         Semver a = Semver.fromString(first);


### PR DESCRIPTION
Fixes #514
