### PR TITLE
fix(config): config classloader strategy for different attach scenarios

### DIFF
--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -27,7 +27,6 @@ import java.nio.charset.Charset;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.security.PrivilegedActionException;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -36,6 +35,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.regex.Matcher;
@@ -50,6 +50,7 @@ import io.cryostat.agent.util.StringUtils;
 
 import dagger.Module;
 import dagger.Provides;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.client.utils.URIBuilder;
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
@@ -177,6 +178,7 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_WEBSERVER_CREDENTIALS_PASS_LENGTH =
             "cryostat.agent.webserver.credentials.pass.length";
 
+    public static final String CRYOSTAT_AGENT_CONFIG_LOADABLE = "cryostat.agent.config.loadable";
     public static final String CRYOSTAT_AGENT_APP_NAME = "cryostat.agent.app.name";
     public static final String CRYOSTAT_AGENT_HOSTNAME = "cryostat.agent.hostname";
     public static final String CRYOSTAT_AGENT_APP_JMX_PORT = "cryostat.agent.app.jmx.port";
@@ -231,24 +233,65 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     public static Config provideConfig() {
-        // if we don't do this then the SmallRye Config loader may end up with a null classloader in
-        // the case that the Agent starts separately and is dynamically attached to a running VM,
-        // which results in an NPE. Here we try to detect and preempt that case and ensure that
-        // there is a reasonable classloader for the SmallRye config loader to use.
-        PrivilegedExceptionAction<ClassLoader> pea =
-                () -> {
-                    ClassLoader cl = Thread.currentThread().getContextClassLoader();
-                    if (cl != null) {
-                        return cl;
-                    }
-                    return new URLClassLoader(new URL[] {Agent.selfJarLocation().toURL()});
-                };
-        try {
-            ClassLoader cl = AccessController.doPrivileged(pea);
-            return ConfigProvider.getConfig(cl);
-        } catch (PrivilegedActionException pae) {
-            throw new RuntimeException(pae);
+        List<Pair<String, Callable<Config>>> fns = new ArrayList<>();
+        fns.add(Pair.of("Simple", ConfigProvider::getConfig));
+        fns.add(
+                Pair.of(
+                        "Current Thread Context Classloader",
+                        () -> {
+                            // if we don't do this then the SmallRye Config loader may end up with a
+                            // null classloader in the case that the Agent starts separately and is
+                            // dynamically attached to a running VM, which results in an NPE. Here
+                            // we try to detect and preempt that case and ensure that there is a
+                            // reasonable classloader for the SmallRye config loader to use.
+                            PrivilegedExceptionAction<ClassLoader> pea =
+                                    () -> {
+                                        ClassLoader cl =
+                                                Thread.currentThread().getContextClassLoader();
+                                        if (cl != null) {
+                                            return cl;
+                                        }
+                                        return new URLClassLoader(
+                                                new URL[] {Agent.selfJarLocation().toURL()});
+                                    };
+                            ClassLoader cl = AccessController.doPrivileged(pea);
+                            return ConfigProvider.getConfig(cl);
+                        }));
+        fns.add(
+                Pair.of(
+                        "Config Class Classloader",
+                        () -> ConfigProvider.getConfig(Config.class.getClassLoader())));
+
+        Config config = null;
+        for (Pair<String, Callable<Config>> fn : fns) {
+            try {
+                log.trace(
+                        "Testing classloader \"{}\" for {} property",
+                        fn.getLeft(),
+                        CRYOSTAT_AGENT_CONFIG_LOADABLE);
+                Config candidate = fn.getRight().call();
+                if (!candidate.getValue(CRYOSTAT_AGENT_CONFIG_LOADABLE, boolean.class)) {
+                    log.warn(
+                            "{} was false. Assuming that this means the {} classloader"
+                                    + " cannot be used to load properties. Do not override this"
+                                    + " configuration property with a blank or false value!",
+                            CRYOSTAT_AGENT_CONFIG_LOADABLE,
+                            fn.getLeft());
+                    continue;
+                }
+                config = candidate;
+                break;
+            } catch (Exception e) {
+                config = null;
+                log.debug(
+                        String.format("Failed to load config from \"%s\" supplier", fn.getLeft()),
+                        e);
+            }
         }
+        if (config == null || !config.getValue(CRYOSTAT_AGENT_CONFIG_LOADABLE, boolean.class)) {
+            log.error("Unable to load configuration from any classloader source!");
+        }
+        return config;
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/util/ResourcesUtil.java
+++ b/src/main/java/io/cryostat/agent/util/ResourcesUtil.java
@@ -17,12 +17,21 @@ package io.cryostat.agent.util;
 
 import java.io.InputStream;
 
+import io.cryostat.agent.Agent;
+
 public class ResourcesUtil {
 
     private ResourcesUtil() {}
 
     public static ClassLoader getClassLoader() {
-        ClassLoader cl = Thread.currentThread().getContextClassLoader();
+        return getClassLoader(Agent.class);
+    }
+
+    public static ClassLoader getClassLoader(Class<?> klazz) {
+        ClassLoader cl = klazz.getClassLoader();
+        if (cl == null) {
+            cl = Thread.currentThread().getContextClassLoader();
+        }
         if (cl == null) {
             cl = ClassLoader.getSystemClassLoader();
         }

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -2,6 +2,8 @@ cryostat.agent.app.name=cryostat-agent
 cryostat.agent.baseuri-range=dns_local
 cryostat.agent.baseuri=
 
+cryostat.agent.config.loadable=true
+
 cryostat.agent.api.writes-enabled=false
 
 cryostat.agent.webserver.host=0.0.0.0


### PR DESCRIPTION
Fixes #486

To test:

Agent:
```
$ ./mvnw clean spotless:apply install
$ podman build -t quay.io/$MYUSER/cryostat-agent-init:0.5.0-snapshot -f src/main/container/Dockerfile .
$ podman push quay.io/$MYUSER/cryostat-agent-init:0.5.0-snapshot
```

----

Test applications:
(directly replace `$MYUSER` in patch - variable substitution probably doesn't work here)
```diff
diff --git a/quarkus-agent/build.bash b/quarkus-agent/build.bash
index 20899a8..0209f1a 100755
--- a/quarkus-agent/build.bash
+++ b/quarkus-agent/build.bash
@@ -19,7 +19,7 @@ podman manifest create "${BUILD_IMG}:${BUILD_TAG}"
 
 for arch in ${ARCHS:-amd64 arm64}; do
     echo "Building for ${arch} ..."
-    podman build --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/src/main/docker/Dockerfile.jvm" "${DIR}"
+    podman build --pull=missing --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/src/main/docker/Dockerfile.jvm" "${DIR}"
     podman manifest add "${BUILD_IMG}:${BUILD_TAG}" containers-storage:"${BUILD_IMG}:linux-${arch}"
 done
 
diff --git a/wildfly/28/Containerfile b/wildfly/28/Containerfile
index 69286cc..729c573 100644
--- a/wildfly/28/Containerfile
+++ b/wildfly/28/Containerfile
@@ -1,6 +1,6 @@
 ARG agent_version
 
-FROM quay.io/cryostat/cryostat-agent-init:${agent_version} AS agent
+FROM quay.io/$MYUSER/cryostat-agent-init:${agent_version} AS agent
 
 FROM quay.io/wildfly/wildfly:28.0.1.Final-jdk17
 COPY --from=agent /cryostat/agent/cryostat-agent-shaded.jar /opt/cryostat/cryostat-agent.jar
diff --git a/wildfly/28/build.bash b/wildfly/28/build.bash
index fcf585d..383244c 100755
--- a/wildfly/28/build.bash
+++ b/wildfly/28/build.bash
@@ -20,7 +20,7 @@ podman manifest create "${BUILD_IMG}:${BUILD_TAG}"
 
 for arch in "${ARCHS[@]}"; do
     echo "Building for ${arch} ..."
-    podman build --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/Containerfile" "${DIR}"
+    podman build --pull=missing --build-arg agent_version="${CRYOSTAT_AGENT_VERSION,,}" --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/Containerfile" "${DIR}"
     podman manifest add "${BUILD_IMG}:${BUILD_TAG}" containers-storage:"${BUILD_IMG}:linux-${arch}"
 done
```
```
$ # you may first need to 'podman rmi' and remove existing local container images
$ ./quarkus-agent/build.bash
$ ./wildfly/28/build.bash
```

----

Cryostat smoketest:
```
$ ./smoketest.bash -OG -s localstack -t quarkus-cryostat-agent,wildfly-28
```

Containers should come up. Open `https://localhost:8443` in a browser and go to Topology. Both sample applications' Agent instances should be discovered.

Check logs with `podman logs compose_quarkus-cryostat-agent_1` or `podman logs compose_wildfly-28_1` and ensure that there are no classloader exceptions or null pointer exceptions etc. in the agent startup sequence. HTTP exceptions early on are normal and expected.