### PR TITLE
fix(config): trim space from hostname tokens

### DIFF
--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -1039,6 +1039,7 @@ public abstract class ConfigModule {
         ScriptHost scriptHost = ScriptHost.newBuilder().build();
         List<String> result = new ArrayList<>(hostNames.length);
         for (String hostName : hostNames) {
+            hostName = hostName.trim();
             Matcher m = HOST_SCRIPT_PATTERN.matcher(hostName);
             if (!m.matches()) {
                 throw new RuntimeException(


### PR DESCRIPTION
This one line fix trims space from provided hostnames, and includes a regression test.

Fixes: #536 