### PR TITLE
chore(logging): Update default logging level

### DIFF
--- a/src/main/resources/simplelogger.properties
+++ b/src/main/resources/simplelogger.properties
@@ -2,3 +2,4 @@
 # prepend config property names with the pom.xml ${shade.prefix} due to bytecode relocation
 ${shade.prefix}.org.slf4j.simpleLogger.showDateTime=true
 ${shade.prefix}.org.slf4j.simpleLogger.dateTimeFormat=yyyy-MM-dd HH:mm:ss:SSS Z
+${shade.prefix}.org.slf4j.simpleLogger.defaultLogLevel=warn


### PR DESCRIPTION
Fixes https://github.com/cryostatio/cryostat-agent/issues/530

Updates the agent logging configuration to default to WARN level. This makes sure that any problems/warnings from the agent are picked up but no additional noise.