### PR TITLE
fix(versioninfo): allow alternate build suffix separator characters

### DIFF
--- a/src/main/java/io/cryostat/agent/VersionInfo.java
+++ b/src/main/java/io/cryostat/agent/VersionInfo.java
@@ -98,7 +98,7 @@ public class VersionInfo {
 
         public static final Pattern VERSION_PATTERN =
                 Pattern.compile(
-                        "^v?(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?:-[a-z0-9\\._-]*)?",
+                        "^v?(?<major>[\\d]+)\\.(?<minor>[\\d]+)\\.(?<patch>[\\d]+)(?:[-_\\.][a-z0-9\\._-]*)?",
                         Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
         private static Logger log = LoggerFactory.getLogger(Semver.class);

--- a/src/test/java/io/cryostat/agent/SemverTest.java
+++ b/src/test/java/io/cryostat/agent/SemverTest.java
@@ -38,10 +38,10 @@ public class SemverTest {
         "1.0.0-SNAPSHOT, 1.0.0, 0",
         "v1.0.0-SNAPSHOT, 1.0.0, 0",
         "v1.0.0, 1.0.0, 0",
-        "v1.5.0.build-suffix1, v1.5.0.build-suffix1, 0",
-        "v1.5.0-build-suffix-2, v1.5.0-build-suffix-2, 0",
-        "v1.5.0_build-suffix-3, v1.5.0_build-suffix-3, 0",
-        "v1.5.0.build.suffix-4, v1.5.0.build.suffix-4, 0",
+        "v1.5.0.build-suffix1, 1.5.0, 0",
+        "v1.5.0-build-suffix-2, 1.5.0, 0",
+        "v1.5.0_build-suffix-3, 1.5.0, 0",
+        "v1.5.0.build.suffix-4, 1.5.0, 0",
     })
     public void test(String first, String second, int result) {
         Semver a = Semver.fromString(first);

--- a/src/test/java/io/cryostat/agent/SemverTest.java
+++ b/src/test/java/io/cryostat/agent/SemverTest.java
@@ -38,6 +38,10 @@ public class SemverTest {
         "1.0.0-SNAPSHOT, 1.0.0, 0",
         "v1.0.0-SNAPSHOT, 1.0.0, 0",
         "v1.0.0, 1.0.0, 0",
+        "v1.5.0.build-suffix1, v1.5.0.build-suffix1, 0",
+        "v1.5.0-build-suffix-2, v1.5.0-build-suffix-2, 0",
+        "v1.5.0_build-suffix-3, v1.5.0_build-suffix-3, 0",
+        "v1.5.0.build.suffix-4, v1.5.0.build.suffix-4, 0",
     })
     public void test(String first, String second, int result) {
         Semver a = Semver.fromString(first);

--- a/src/test/java/io/cryostat/agent/VersionInfoTest.java
+++ b/src/test/java/io/cryostat/agent/VersionInfoTest.java
@@ -28,7 +28,18 @@ public class VersionInfoTest {
     static final Semver serverMax = Semver.fromString("2.0.0");
 
     @ParameterizedTest
-    @CsvSource({"1.0.0, true", "2.0.0, false", "3.0.0, false", "0.1.0, false", "1.1.0, true"})
+    @CsvSource({
+        "1.0.0, true",
+        "2.0.0, false",
+        "3.0.0, false",
+        "0.1.0, false",
+        "1.1.0, true",
+        "v1.5.0, true",
+        "v1.5.0.build-suffix1, true",
+        "v1.5.0-build-suffix-2, true",
+        "v1.5.0_build-suffix-3, true",
+        "v1.5.0.build.suffix-4, true",
+    })
     public void test(String serverVersion, boolean inRange) {
         VersionInfo info = new VersionInfo(Semver.UNKNOWN, serverMin, serverMax);
         Semver actual = Semver.fromString(serverVersion);


### PR DESCRIPTION
Fixes #598
