### PR TITLE
fix(signal): avoid NPE on shutdown

### DIFF
--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -396,7 +396,11 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
 
         @Override
         public void handle(Signal sig) {
-            log.debug("Caught SIG{}({})", sig.getName(), sig.getNumber());
+            if (sig == null) {
+                log.debug("'null' signal handler invoked");
+            } else {
+                log.debug("Caught SIG{}({})", sig.getName(), sig.getNumber());
+            }
             if (needsCleanup.getAndSet(false)) {
                 performCleanup(sig);
             }

--- a/src/main/java/io/cryostat/agent/harvest/HarvestModule.java
+++ b/src/main/java/io/cryostat/agent/harvest/HarvestModule.java
@@ -51,7 +51,7 @@ public abstract class HarvestModule {
         exitSettings.maxAge = exitMaxAge;
         exitSettings.maxSize = exitMaxSize;
         RecordingSettings periodicSettings = new RecordingSettings();
-        periodicSettings.name = Harvester.RECORDING_NAME_HARVESTER_SNAPSHOT;
+        periodicSettings.name = Harvester.RECORDING_NAME_PERIODIC;
         periodicSettings.maxAge = maxAge > 0 ? maxAge : (long) (period * 1.5);
         periodicSettings.maxSize = maxSize;
         return new Harvester(

--- a/src/main/java/io/cryostat/agent/harvest/Harvester.java
+++ b/src/main/java/io/cryostat/agent/harvest/Harvester.java
@@ -285,11 +285,15 @@ public class Harvester implements FlightRecorderListener {
     }
 
     public void handleNewRecording(TemplatedRecording tr) {
+        this.handleNewRecording(tr, this.periodicSettings);
+    }
+
+    public void handleNewRecording(TemplatedRecording tr, RecordingSettings settings) {
         try {
             Recording recording = tr.getRecording();
             recording.setToDisk(true);
             recording.setDumpOnExit(true);
-            recording = this.periodicSettings.apply(recording);
+            recording = settings.apply(recording);
             Path path = Files.createTempFile(null, null);
             Files.write(path, new byte[0], StandardOpenOption.TRUNCATE_EXISTING);
             recording.setDestination(path);
@@ -316,10 +320,10 @@ public class Harvester implements FlightRecorderListener {
                             .createRecordingWithPredefinedTemplate(template)
                             .ifPresent(
                                     recording -> {
+                                        handleNewRecording(recording, this.periodicSettings);
                                         recording
                                                 .getRecording()
                                                 .setName("cryostat-agent-harvester");
-                                        handleNewRecording(recording);
                                         this.sownRecording = Optional.of(recording);
                                         recording.getRecording().start();
                                         log.info(

--- a/src/main/java/io/cryostat/agent/harvest/Harvester.java
+++ b/src/main/java/io/cryostat/agent/harvest/Harvester.java
@@ -270,7 +270,7 @@ public class Harvester implements FlightRecorderListener {
                     }
                     try {
                         if (!exitUploadInitiated.getAndSet(true)) {
-                            uploadOngoing(PushType.ON_STOP, exitSettings).get();
+                            uploadOngoing(PushType.ON_EXIT, exitSettings).get();
                         }
                     } catch (ExecutionException | InterruptedException e) {
                         log.error("Exit upload failed", e);
@@ -381,13 +381,13 @@ public class Harvester implements FlightRecorderListener {
 
     private Future<Void> uploadRecording(TemplatedRecording tr) throws IOException {
         Path exitPath = exitPaths.get(tr);
-        return client.upload(PushType.EMERGENCY, Optional.of(tr), maxFiles, exitPath);
+        return client.upload(PushType.ON_STOP, Optional.of(tr), maxFiles, exitPath);
     }
 
     public enum PushType {
         SCHEDULED,
         ON_STOP,
-        EMERGENCY,
+        ON_EXIT,
     }
 
     public static class RecordingSettings implements UnaryOperator<Recording> {

--- a/src/main/java/io/cryostat/agent/harvest/Harvester.java
+++ b/src/main/java/io/cryostat/agent/harvest/Harvester.java
@@ -50,7 +50,7 @@ import org.slf4j.LoggerFactory;
 public class Harvester implements FlightRecorderListener {
 
     public static final String RECORDING_NAME_ON_EXIT = "onexit";
-    public static final String RECORDING_NAME_HARVESTER_SNAPSHOT = "harvester_snapshot";
+    public static final String RECORDING_NAME_PERIODIC = "cryostat-agent-harvester";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -321,9 +321,6 @@ public class Harvester implements FlightRecorderListener {
                             .ifPresent(
                                     recording -> {
                                         handleNewRecording(recording, this.periodicSettings);
-                                        recording
-                                                .getRecording()
-                                                .setName("cryostat-agent-harvester");
                                         this.sownRecording = Optional.of(recording);
                                         recording.getRecording().start();
                                         log.info(

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -34,7 +34,6 @@ import java.util.stream.Collectors;
 import javax.inject.Inject;
 
 import io.cryostat.agent.FlightRecorderHelper;
-import io.cryostat.agent.harvest.Harvester;
 import io.cryostat.agent.util.StringUtils;
 import io.cryostat.libcryostat.serialization.SerializableRecordingDescriptor;
 import io.cryostat.libcryostat.templates.InvalidEventTemplateException;
@@ -131,10 +130,6 @@ class RecordingsContext implements RemoteContext {
         try (OutputStream response = exchange.getResponseBody()) {
             List<SerializableRecordingDescriptor> recordings =
                     flightRecorder.getRecordings().stream()
-                            .filter(
-                                    r ->
-                                            !Harvester.RECORDING_NAME_HARVESTER_SNAPSHOT.equals(
-                                                    r.getName()))
                             .map(SerializableRecordingDescriptor::new)
                             .collect(Collectors.toList());
             exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);


### PR DESCRIPTION
1. avoid an NPE in signal handling on shutdown, which can cause the exit upload to fail
2. ensure that the recordings list reported by the Agent matches what is also seen when querying via JMX
3. rename the harvester recording to be more informative

Fixes #608 
Fixes #609