### PR TITLE
chore(container): set base FROM directly without build arg

### DIFF
--- a/src/main/container/Dockerfile
+++ b/src/main/container/Dockerfile
@@ -1,5 +1,4 @@
-ARG BASEIMAGE=registry.access.redhat.com/ubi9-micro:9.5
-FROM ${BASEIMAGE}
+FROM registry.access.redhat.com/ubi9-micro:9.5
 ARG OUTDIR=/cryostat/agent
 COPY target/cryostat-agent-*-shaded.jar ${OUTDIR}/
 RUN ln -s ${OUTDIR}/cryostat-agent-*-shaded.jar ${OUTDIR}/cryostat-agent-shaded.jar


### PR DESCRIPTION
Related to #390
See #561

Sets the `FROM` line with the base image version string directly, rather than using the `BASEIMAGE` build argument. The indirection of the `BASEIMAGE` build argument seems to prevent Dependabot updates, probably because Dependabot doesn't try to substitute the default variable value.
