### PR TITLE
feat(diagnostics): Add thread dump capturing to diagnostics endpoint

### DIFF
--- a/src/main/java/io/cryostat/agent/remote/InvokeContext.java
+++ b/src/main/java/io/cryostat/agent/remote/InvokeContext.java
@@ -18,7 +18,6 @@ package io.cryostat.agent.remote;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.lang.management.ManagementFactory;
 import java.util.Objects;
 
@@ -27,7 +26,6 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.redhat.insights.agent.shaded.org.apache.commons.codec.Charsets;
 import com.sun.net.httpserver.HttpExchange;
 import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.config.Config;
@@ -75,22 +73,9 @@ class InvokeContext extends MutatingRemoteContext {
                                         req.signature);
 
                         if (Objects.nonNull(response)) {
-                            // If a thread dump was requested we need to send it back
-                            if (req.operation.equals(DUMP_THREADS)) {
-                                exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
-                                try (OutputStreamWriter writer =
-                                        new OutputStreamWriter(
-                                                exchange.getResponseBody(), Charsets.UTF_8)) {
-                                    writer.write(response.toString());
-                                } catch (Exception e) {
-                                    log.error("Failed to write thread dump to response: ", e);
-                                    throw e;
-                                }
-                            } else {
-                                exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
-                                try (OutputStream responseStream = exchange.getResponseBody()) {
-                                    mapper.writeValue(responseStream, response);
-                                }
+                            exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
+                            try (OutputStream responseStream = exchange.getResponseBody()) {
+                                mapper.writeValue(responseStream, response);
                             }
                         } else {
                             exchange.sendResponseHeaders(HttpStatus.SC_ACCEPTED, BODY_LENGTH_NONE);

--- a/src/main/java/io/cryostat/agent/remote/InvokeContext.java
+++ b/src/main/java/io/cryostat/agent/remote/InvokeContext.java
@@ -27,6 +27,7 @@ import javax.management.MBeanServer;
 import javax.management.ObjectName;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.redhat.insights.agent.shaded.org.apache.commons.codec.Charsets;
 import com.sun.net.httpserver.HttpExchange;
 import org.apache.http.HttpStatus;
 import org.eclipse.microprofile.config.Config;
@@ -79,10 +80,11 @@ class InvokeContext extends MutatingRemoteContext {
                                 exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);
                                 try (OutputStreamWriter writer =
                                         new OutputStreamWriter(
-                                                exchange.getResponseBody(), "UTF_8")) {
+                                                exchange.getResponseBody(), Charsets.UTF_8)) {
                                     writer.write(response.toString());
                                 } catch (Exception e) {
                                     log.error("Failed to write thread dump to response: ", e);
+                                    throw e;
                                 }
                             } else {
                                 exchange.sendResponseHeaders(HttpStatus.SC_OK, BODY_LENGTH_UNKNOWN);


### PR DESCRIPTION
Related to https://github.com/cryostatio/cryostat/issues/135

Adds the ability to capture thread dumps to the agent's mbean-invoke endpoint. The original implementation of the endpoint is already fairly flexible, essentially acting as a wrapper around the mbean.invoke method, so we just need to extend the check for valid/supported operations, and add a further check if we're doing a thread dump so it can be written to the response body as-is.

Currently supports the threadPrint operation but leaves an opening for the threadDumpToFile operation to be supported later if necessary. Note that the format of threadDumpToFile isn't supported by existing support tooling so it won't work for the purposes of the linked issue, only threadPrint.

Opening as Draft until the other pieces of the feature are in place.