### PR TITLE
fix(insights): inherit log level from Cryostat agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Smart Triggers may define more complex conditions that test multiple metrics:
 These may be passed as an argument to the Cryostat Agent, for example:
 
 ```
-JAVA_OPTIONS="-javaagent:-Dcryostat.agent.baseuri=http://cryostat.local!/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=[ProcessCpuLoad>0.2]~profile
+JAVA_OPTIONS="-javaagent:/deployments/app/cryostat-agent-${CRYOSTAT_AGENT_VERSION}.jar=-Dcryostat.agent.baseuri=http://cryostat.local![ProcessCpuLoad>0.2]~profile
 ```
 
 (note the '!' separator between system properties overrides and Smart Triggers)

--- a/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
+++ b/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
@@ -25,6 +25,7 @@ import java.util.function.Supplier;
 
 import io.cryostat.agent.ConfigModule;
 import io.cryostat.agent.model.PluginInfo;
+import io.cryostat.agent.shaded.ShadeLogger;
 
 import com.redhat.insights.agent.AgentBasicReport;
 import com.redhat.insights.agent.AgentConfiguration;
@@ -44,7 +45,6 @@ import org.slf4j.simple.SimpleLogger;
 public class InsightsAgentHelper {
 
     private static final String INSIGHTS_SVC = "INSIGHTS_SVC";
-    private static final String SHADE_PREFIX = "io.cryostat.agent.shaded.";
     static final String RHT_INSIGHTS_JAVA_OPT_OUT = "rht.insights.java.opt-out";
     static final String RHT_INSIGHTS_JAVA_DEBUG = "rht.insights.java.debug";
 
@@ -79,7 +79,11 @@ public class InsightsAgentHelper {
             defaultLogLevel = "debug";
         } else {
             // Otherwise, apply any log level set for the Cryostat agent
-            defaultLogLevel = System.getProperty(SHADE_PREFIX + SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
+            defaultLogLevel =
+                    System.getProperty(
+                            ShadeLogger.class.getPackageName()
+                                    + "."
+                                    + SimpleLogger.DEFAULT_LOG_LEVEL_KEY);
         }
         if (defaultLogLevel != null) {
             // Set Insights logger default log level property


### PR DESCRIPTION
This PR retrieves the `defaultLogLevel` property for the Cryostat agent and applies it to the Insights agent's shaded logger. This can still be overriden by the `RHT_INSIGHTS_JAVA_DEBUG` config parameter to force debug logging for Insights only.

Fixes: https://github.com/cryostatio/cryostat-operator/issues/1090