### PR TITLE
build(maven): update Maven Central publishing URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -603,8 +603,8 @@
                   <nexus2>
                     <maven-central>
                       <active>ALWAYS</active>
-                      <url>https://s01.oss.sonatype.org/service/local</url>
-                      <snapshotUrl>https://s01.oss.sonatype.org/content/repositories/snapshots</snapshotUrl>
+                      <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
+                      <snapshotUrl>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</snapshotUrl>
                       <closeRepository>true</closeRepository>
                       <releaseRepository>true</releaseRepository>
                       <stagingRepositories>target/staging-deploy</stagingRepositories>
@@ -623,8 +623,8 @@
     <id>snapshots</id>
     <repositories>
       <repository>
-        <id>s01.oss.sonatype.org-snapshot</id>
-        <url>https://s01.oss.sonatype.org/content/repositories/snapshots/</url>
+        <id>ossrh-staging-api.central.sonatype.com-snapshot</id>
+        <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/</url>
         <releases>
           <enabled>false</enabled>
         </releases>

--- a/pom.xml
+++ b/pom.xml
@@ -600,15 +600,23 @@
               </signing>
               <deploy>
                 <maven>
+                  <mavenCentral>
+                    <release-deploy>
+                      <active>RELEASE</active>
+                      <url>https://central.sonatype.com/api/v1/publisher</url>
+                      <stagingRepositories>target/staging-deploy</stagingRepositories>
+                    </release-deploy>
+                  </mavenCentral>
                   <nexus2>
-                    <maven-central>
-                      <active>ALWAYS</active>
-                      <url>https://ossrh-staging-api.central.sonatype.com/service/local</url>
-                      <snapshotUrl>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots</snapshotUrl>
+                    <snapshot-deploy>
+                      <active>SNAPSHOT</active>
+                      <snapshotUrl>https://central.sonatype.com/repository/maven-snapshots/</snapshotUrl>
+                      <applyMavenCentralRules>true</applyMavenCentralRules>
+                      <snapshotSupported>true</snapshotSupported>
                       <closeRepository>true</closeRepository>
                       <releaseRepository>true</releaseRepository>
                       <stagingRepositories>target/staging-deploy</stagingRepositories>
-                    </maven-central>
+                    </snapshot-deploy>
                   </nexus2>
                 </maven>
               </deploy>
@@ -623,8 +631,8 @@
     <id>snapshots</id>
     <repositories>
       <repository>
-        <id>ossrh-staging-api.central.sonatype.com-snapshot</id>
-        <url>https://ossrh-staging-api.central.sonatype.com/content/repositories/snapshots/</url>
+        <id>central.sonatype.com-snapshot</id>
+        <url>https://central.sonatype.com/repository/maven-snapshots/</url>
         <releases>
           <enabled>false</enabled>
         </releases>


### PR DESCRIPTION
Following the sunset of OSSRH, Sonatype recommends using their [Staging API](https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/) to migrate to the Central Publisher Portal to maintain compatibility with existing tools.

Fixes: #669 