### PR TITLE
fix(triggers): Fix triggerParser warning to use optional value

### DIFF
--- a/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerParser.java
@@ -55,7 +55,7 @@ public class TriggerParser {
         if (triggerPath.isPresent() && !checkDir()) {
             log.warn(
                     "Configuration directory {} doesn't exist or is missing permissions",
-                    triggerPath.toString());
+                    triggerPath.get().toString());
             return Collections.emptyList();
         }
         try {


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat-agent/issues/672

I'm unable to reproduce the original issue, however the log warning can be corrected. This PR corrects the log warning to get the value of the Optional rather than using a direct toString. 

To test:
- Pull and build this PR
- Launch a sample application with the built version of the agent
- Specify a path that doesn't exist (CRYOSTAT_AGENT_SMART_TRIGGER_CONFIG_PATH: foo)
- Check that a sensible message gets logged (WARN io.cryostat.agent.triggers.TriggerParser - Configuration directory foo doesn't exist or is missing permissions)