### PR TITLE
feat(instrumentation): Add JMC Agent Mbean to allowed operations on /mbean-invoke/

### DIFF
--- a/src/main/java/io/cryostat/agent/remote/InvokeContext.java
+++ b/src/main/java/io/cryostat/agent/remote/InvokeContext.java
@@ -149,6 +149,8 @@ class InvokeContext extends MutatingRemoteContext {
                 "com.sun.management:type=HotSpotDiagnostic";
         private static final String DIAGNOSTIC_COMMAND_BEAN_NAME =
                 "com.sun.management:type=DiagnosticCommand";
+        private static final String JMC_AGENT_BEAN_NAME =
+                "org.openjdk.jmc.jfr.agent:type=AgentController";
 
         public boolean isValid() {
             if (CRYOSTAT_AGENT_BEAN_NAME.equals(beanName)) {
@@ -161,6 +163,9 @@ class InvokeContext extends MutatingRemoteContext {
             if (DIAGNOSTIC_COMMAND_BEAN_NAME.equals(beanName)
                     && (DUMP_THREADS.equals(this.operation)
                             || DUMP_THREADS_TO_FIlE.equals(this.operation))) {
+                return true;
+            }
+            if (JMC_AGENT_BEAN_NAME.equals(beanName)) {
                 return true;
             }
             return false;


### PR DESCRIPTION
Related to: https://github.com/cryostatio/cryostat/issues/1195

Adds the JMC AgentController MBean to the list of allowed operations on the /mbean-invoke/ endpoint. This is needed to facilitate JMC Agent control over Agent HTTP connections. With this the server will be able to rely on connection.invokeMbeanOperation to perform JMC agent operations.