### PR TITLE
feat(discovery): implement publication fillStrategy and additional context

### DIFF
--- a/build.bash
+++ b/build.bash
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+set -xe
+
+DIR="$(dirname "$(readlink -f "$0")")"
+
+pushd "${DIR}"
+function cleanup() {
+    popd
+}
+trap cleanup EXIT
+
+BUILD_IMG="${APP_REGISTRY:-quay.io}/${APP_NAMESPACE:-cryostat}/${APP_NAME:-cryostat-agent-init}"
+BUILD_TAG="${APP_VERSION:-$(mvn -f "${DIR}/pom.xml" help:evaluate -B -q -DforceStdout -Dexpression=project.version)}"
+
+"${DIR}/mvnw" -B -U -Psnapshots clean install
+
+podman manifest create "${BUILD_IMG}:${BUILD_TAG}"
+
+for arch in ${ARCHS:-amd64 arm64}; do
+    echo "Building for ${arch} ..."
+    podman build --pull=missing --platform="linux/${arch}" -t "${BUILD_IMG}:linux-${arch}" -f "${DIR}/src/main/container/Dockerfile" "${DIR}"
+    podman manifest add "${BUILD_IMG}:${BUILD_TAG}" containers-storage:"${BUILD_IMG}:linux-${arch}"
+done
+
+for tag in ${TAGS}; do
+    podman tag "${BUILD_IMG}:${BUILD_TAG}" "${BUILD_IMG}:${tag}"
+done
+
+if [ "${PUSH_MANIFEST}" = "true" ]; then
+    podman manifest push "${BUILD_IMG}:${BUILD_TAG}" "docker://${BUILD_IMG}:${BUILD_TAG}"
+    for tag in ${TAGS}; do
+        podman manifest push "${BUILD_IMG}:${tag}" "docker://${BUILD_IMG}:${tag}"
+    done
+fi
+
+echo "Image: ${BUILD_IMG}:${BUILD_TAG}"

--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,10 @@
                 <shadedPattern>${shade.prefix}.io.smallrye.config</shadedPattern>
               </relocation>
               <relocation>
+                <pattern>org.eclipse.microprofile</pattern>
+                <shadedPattern>${shade.prefix}.org.eclipse.microprofile</shadedPattern>
+              </relocation>
+              <relocation>
                 <pattern>org.jboss</pattern>
                 <shadedPattern>${shade.prefix}.org.jboss</shadedPattern>
               </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -216,15 +216,9 @@
     <artifactId>jackson-databind</artifactId>
   </dependency>
   <dependency>
-    <groupId>org.eclipse.microprofile.config</groupId>
-    <artifactId>microprofile-config-api</artifactId>
-    <scope>compile</scope>
-  </dependency>
-  <dependency>
     <groupId>io.smallrye.config</groupId>
     <artifactId>smallrye-config</artifactId>
     <version>${io.smallrye.config.version}</version>
-    <scope>runtime</scope>
   </dependency>
   <dependency>
     <groupId>com.redhat.insights</groupId>
@@ -369,10 +363,6 @@
               <relocation>
                 <pattern>io.smallrye.config</pattern>
                 <shadedPattern>${shade.prefix}.io.smallrye.config</shadedPattern>
-              </relocation>
-              <relocation>
-                <pattern>org.eclipse.microprofile</pattern>
-                <shadedPattern>${shade.prefix}.org.eclipse.microprofile</shadedPattern>
               </relocation>
               <relocation>
                 <pattern>org.jboss</pattern>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
   <org.apache.commons.io.version>2.21.0</org.apache.commons.io.version>
   <org.apache.httpcomponents.httpclient.version>5.4.4</org.apache.httpcomponents.httpclient.version>
   <com.fasterxml.jackson.version>2.21.0</com.fasterxml.jackson.version>
-  <io.smallrye.config.version>3.10.2</io.smallrye.config.version>
+  <io.smallrye.config.version>3.10.2</io.smallrye.config.version><!-- latest version which supports JDK 11 -->
   <org.slf4j.version>2.0.17</org.slf4j.version>
   <org.projectnessie.cel.bom.version>0.5.2</org.projectnessie.cel.bom.version>
   <com.google.protobuf-java.version>4.31.1</com.google.protobuf-java.version>

--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -56,8 +56,8 @@ import com.sun.tools.attach.AttachNotSupportedException;
 import com.sun.tools.attach.VirtualMachine;
 import com.sun.tools.attach.VirtualMachineDescriptor;
 import dagger.Component;
+import io.smallrye.config.SmallRyeConfig;
 import org.apache.commons.lang3.tuple.Pair;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import picocli.CommandLine;
@@ -373,7 +373,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
     @Singleton
     @Component(modules = {MainModule.class})
     interface Client {
-        Config config();
+        SmallRyeConfig config();
 
         @Named(ConfigModule.CRYOSTAT_AGENT_FLEET_SAMPLING_RATIO)
         double fleetSamplingRatio();

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -1038,7 +1038,7 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY)
     public static String provideCryostatAgentPublishFillStrategy(SmallRyeConfig config) {
         return config.getOptionalValue(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY, String.class)
-                .orElse("");
+                .orElse("NONE");
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -206,6 +206,10 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_EXIT_DEREGISTRATION_TIMEOUT_MS =
             "cryostat.agent.exit.deregistration.timeout-ms";
 
+    public static final String CRYOSTAT_AGENT_PUBLISH_CONTEXT = "cryostat.agent.publish.context";
+    public static final String CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY =
+            "cryostat.agent.publish.fill-strategy";
+
     public static final String CRYOSTAT_AGENT_HARVESTER_PERIOD_MS =
             "cryostat.agent.harvester.period-ms";
     public static final String CRYOSTAT_AGENT_HARVESTER_TEMPLATE =
@@ -1019,6 +1023,21 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_EXIT_DEREGISTRATION_TIMEOUT_MS)
     public static long provideCryostatAgentExitDeregistrationTimeoutMs(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_EXIT_DEREGISTRATION_TIMEOUT_MS, long.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_PUBLISH_CONTEXT)
+    public static Map<String, String> provideCryostatAgentPublishContext(SmallRyeConfig config) {
+        return config.getValues(CRYOSTAT_AGENT_PUBLISH_CONTEXT, String.class, String.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY)
+    public static String provideCryostatAgentPublishFillStrategy(SmallRyeConfig config) {
+        return config.getOptionalValue(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY, String.class)
+                .orElse("");
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -674,7 +674,7 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_TIME)
-    public static int provideCryostatAgentWebclientResponseRetryTime(Config config) {
+    public static int provideCryostatAgentWebclientResponseRetryTime(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_TIME, int.class);
     }
 
@@ -682,7 +682,7 @@ public abstract class ConfigModule {
     @Singleton
     @Named(CRYOSTAT_AGENT_WEBCLIENT_HTTP_USE_PREEMPTIVE_AUTHENTICATION)
     public static boolean provideCryostatAgentWebclientHttpUsePreemptiveAuthentication(
-            Config config) {
+            SmallRyeConfig config) {
         return config.getValue(
                 CRYOSTAT_AGENT_WEBCLIENT_HTTP_USE_PREEMPTIVE_AUTHENTICATION, boolean.class);
     }

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -1029,7 +1029,8 @@ public abstract class ConfigModule {
     @Singleton
     @Named(CRYOSTAT_AGENT_PUBLISH_CONTEXT)
     public static Map<String, String> provideCryostatAgentPublishContext(SmallRyeConfig config) {
-        return config.getValues(CRYOSTAT_AGENT_PUBLISH_CONTEXT, String.class, String.class);
+        return config.getOptionalValues(CRYOSTAT_AGENT_PUBLISH_CONTEXT, String.class, String.class)
+                .orElse(Map.of());
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -1037,8 +1037,7 @@ public abstract class ConfigModule {
     @Singleton
     @Named(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY)
     public static String provideCryostatAgentPublishFillStrategy(SmallRyeConfig config) {
-        return config.getOptionalValue(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY, String.class)
-                .orElse("NONE");
+        return config.getValue(CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY, String.class);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -996,7 +996,7 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_ASYNC_PROFILER_REPOSITORY_PATH)
-    public static Path provideCryostatAgentAsyncProfilerRepositoryPath(Config config) {
+    public static Path provideCryostatAgentAsyncProfilerRepositoryPath(SmallRyeConfig config) {
         try {
             Path repository =
                     config.getOptionalValue(

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -604,17 +604,17 @@ public class CryostatClient {
     @SuppressFBWarnings("EI_EXPOSE_REP")
     public static class DiscoveryPublication {
 
-        final String fillAlgorithm;
+        final String fillStrategy;
         final Map<String, String> context = new HashMap<>();
         final Collection<DiscoveryNode> nodes = new ArrayList<>();
 
-        public DiscoveryPublication(String fillAlgorithm, Map<String, String> context) {
-            this.fillAlgorithm = fillAlgorithm;
+        public DiscoveryPublication(String fillStrategy, Map<String, String> context) {
+            this.fillStrategy = fillStrategy;
             this.context.putAll(context);
         }
 
         DiscoveryPublication(DiscoveryPublication o, Collection<DiscoveryNode> nodes) {
-            this(o.fillAlgorithm, o.context);
+            this(o.fillStrategy, o.context);
             this.nodes.addAll(nodes);
         }
 
@@ -622,8 +622,8 @@ public class CryostatClient {
             return nodes;
         }
 
-        public String getFillAlgorithm() {
-            return fillAlgorithm;
+        public String getFillStrategy() {
+            return fillStrategy;
         }
 
         public Map<String, String> getContext() {
@@ -642,7 +642,7 @@ public class CryostatClient {
 
         @Override
         public int hashCode() {
-            return Objects.hash(nodes, fillAlgorithm, context);
+            return Objects.hash(nodes, fillStrategy, context);
         }
 
         @Override
@@ -658,7 +658,7 @@ public class CryostatClient {
             }
             DiscoveryPublication other = (DiscoveryPublication) obj;
             return Objects.equals(nodes, other.nodes)
-                    && Objects.equals(fillAlgorithm, other.fillAlgorithm)
+                    && Objects.equals(fillStrategy, other.fillStrategy)
                     && Objects.equals(context, other.context);
         }
     }

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -51,6 +51,7 @@ import java.util.Arrays;
 import java.util.Base64;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Executors;
@@ -795,9 +796,20 @@ public abstract class MainModule {
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_BASEURI) URI baseUri,
-            @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm) {
+            @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
+            @Named(ConfigModule.CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY) String fillAlgorithm,
+            @Named(ConfigModule.CRYOSTAT_AGENT_PUBLISH_CONTEXT)
+                    Map<String, String> publishContext) {
         return new CryostatClient(
-                executor, objectMapper, http, instanceId, jvmId, appName, baseUri, realm);
+                executor,
+                objectMapper,
+                http,
+                instanceId,
+                jvmId,
+                appName,
+                baseUri,
+                realm,
+                new CryostatClient.DiscoveryPublication(fillAlgorithm, publishContext));
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -797,7 +797,7 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
             @Named(ConfigModule.CRYOSTAT_AGENT_BASEURI) URI baseUri,
             @Named(ConfigModule.CRYOSTAT_AGENT_REALM) String realm,
-            @Named(ConfigModule.CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY) String fillAlgorithm,
+            @Named(ConfigModule.CRYOSTAT_AGENT_PUBLISH_FILL_STRATEGY) String fillStrategy,
             @Named(ConfigModule.CRYOSTAT_AGENT_PUBLISH_CONTEXT)
                     Map<String, String> publishContext) {
         return new CryostatClient(
@@ -809,7 +809,7 @@ public abstract class MainModule {
                 appName,
                 baseUri,
                 realm,
-                new CryostatClient.DiscoveryPublication(fillAlgorithm, publishContext));
+                new CryostatClient.DiscoveryPublication(fillStrategy, publishContext));
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -45,7 +45,8 @@ import org.slf4j.LoggerFactory;
 
 public class Registration {
 
-    private static final String NODE_TYPE = "JVM";
+    private static final String AGENT_NODE_TYPE = "CryostatAgent";
+    private static final String JMX_NODE_TYPE = "JVM";
 
     private final Logger log = LoggerFactory.getLogger(getClass());
 
@@ -333,7 +334,8 @@ public class Registration {
                         javaMain,
                         startTime);
         discoveryNodes.add(
-                new DiscoveryNode(appName + "-agent-" + pluginInfo.getId(), NODE_TYPE, httpSelf));
+                new DiscoveryNode(
+                        appName + "-agent-" + pluginInfo.getId(), AGENT_NODE_TYPE, httpSelf));
 
         if (!registrationJmxIgnore && jmxPort > 0) {
             uri =
@@ -356,7 +358,8 @@ public class Registration {
                             javaMain,
                             startTime);
             discoveryNodes.add(
-                    new DiscoveryNode(appName + "-jmx-" + pluginInfo.getId(), NODE_TYPE, jmxSelf));
+                    new DiscoveryNode(
+                            appName + "-jmx-" + pluginInfo.getId(), JMX_NODE_TYPE, jmxSelf));
         }
 
         return discoveryNodes;

--- a/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
+++ b/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
@@ -53,6 +53,7 @@ public class InsightsAgentHelper {
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private final Instrumentation instrumentation;
 
+    @SuppressFBWarnings("EI_EXPOSE_REP2")
     private final SmallRyeConfig config;
 
     public InsightsAgentHelper(SmallRyeConfig config, Instrumentation instrumentation) {

--- a/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
+++ b/src/main/java/io/cryostat/agent/insights/InsightsAgentHelper.java
@@ -39,7 +39,7 @@ import com.redhat.insights.agent.shaded.logging.InsightsLogger;
 import com.redhat.insights.agent.shaded.reports.InsightsReport;
 import com.redhat.insights.agent.shaded.tls.PEMSupport;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import org.eclipse.microprofile.config.Config;
+import io.smallrye.config.SmallRyeConfig;
 import org.slf4j.simple.SimpleLogger;
 
 public class InsightsAgentHelper {
@@ -53,9 +53,9 @@ public class InsightsAgentHelper {
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     private final Instrumentation instrumentation;
 
-    private final Config config;
+    private final SmallRyeConfig config;
 
-    public InsightsAgentHelper(Config config, Instrumentation instrumentation) {
+    public InsightsAgentHelper(SmallRyeConfig config, Instrumentation instrumentation) {
         this.config = config;
         this.instrumentation = instrumentation;
     }

--- a/src/main/java/io/cryostat/agent/remote/AsyncProfilerContext.java
+++ b/src/main/java/io/cryostat/agent/remote/AsyncProfilerContext.java
@@ -50,9 +50,9 @@ import io.cryostat.agent.ConfigModule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.smallrye.config.SmallRyeConfig;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpStatus;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,7 +75,7 @@ class AsyncProfilerContext extends MutatingRemoteContext {
 
     @Inject
     AsyncProfilerContext(
-            Config config,
+            SmallRyeConfig config,
             ObjectMapper mapper,
             ScheduledExecutorService scheduler,
             @Named(ConfigModule.CRYOSTAT_AGENT_ASYNC_PROFILER_REPOSITORY_PATH) Path repository) {

--- a/src/main/java/io/cryostat/agent/remote/InvokeContext.java
+++ b/src/main/java/io/cryostat/agent/remote/InvokeContext.java
@@ -39,8 +39,8 @@ import io.cryostat.libcryostat.net.CryostatAgentMXBean;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
+import io.smallrye.config.SmallRyeConfig;
 import org.apache.hc.core5.http.HttpStatus;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,7 +54,7 @@ class InvokeContext extends MutatingRemoteContext {
     private CryostatClient client;
 
     @Inject
-    InvokeContext(ObjectMapper mapper, Config config, CryostatClient client) {
+    InvokeContext(ObjectMapper mapper, SmallRyeConfig config, CryostatClient client) {
         super(config);
         this.mapper = mapper;
         this.client = client;

--- a/src/main/java/io/cryostat/agent/remote/MutatingRemoteContext.java
+++ b/src/main/java/io/cryostat/agent/remote/MutatingRemoteContext.java
@@ -17,13 +17,13 @@ package io.cryostat.agent.remote;
 
 import io.cryostat.agent.ConfigModule;
 
-import org.eclipse.microprofile.config.Config;
+import io.smallrye.config.SmallRyeConfig;
 
 public abstract class MutatingRemoteContext implements RemoteContext {
 
-    protected final Config config;
+    protected final SmallRyeConfig config;
 
-    protected MutatingRemoteContext(Config config) {
+    protected MutatingRemoteContext(SmallRyeConfig config) {
         this.config = config;
     }
 
@@ -32,7 +32,7 @@ public abstract class MutatingRemoteContext implements RemoteContext {
         return apiWritesEnabled(config);
     }
 
-    public static boolean apiWritesEnabled(Config config) {
+    public static boolean apiWritesEnabled(SmallRyeConfig config) {
         return config.getValue(ConfigModule.CRYOSTAT_AGENT_API_WRITES_ENABLED, boolean.class);
     }
 }

--- a/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
+++ b/src/main/java/io/cryostat/agent/remote/RecordingsContext.java
@@ -40,11 +40,11 @@ import io.cryostat.libcryostat.templates.InvalidEventTemplateException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
+import io.smallrye.config.SmallRyeConfig;
 import jdk.jfr.Recording;
 import jdk.jfr.RecordingState;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.HttpStatus;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,12 +55,13 @@ class RecordingsContext implements RemoteContext {
             Pattern.compile("^" + PATH + "(\\d+)$", Pattern.MULTILINE);
 
     private final Logger log = LoggerFactory.getLogger(getClass());
-    private final Config config;
+    private final SmallRyeConfig config;
     private final ObjectMapper mapper;
     private final FlightRecorderHelper flightRecorder;
 
     @Inject
-    RecordingsContext(Config config, ObjectMapper mapper, FlightRecorderHelper flightRecorder) {
+    RecordingsContext(
+            SmallRyeConfig config, ObjectMapper mapper, FlightRecorderHelper flightRecorder) {
         this.config = config;
         this.mapper = mapper;
         this.flightRecorder = flightRecorder;

--- a/src/main/java/io/cryostat/agent/remote/SmartTriggersContext.java
+++ b/src/main/java/io/cryostat/agent/remote/SmartTriggersContext.java
@@ -27,9 +27,9 @@ import io.cryostat.agent.triggers.TriggerEvaluator;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sun.net.httpserver.HttpExchange;
+import io.smallrye.config.SmallRyeConfig;
 import jakarta.inject.Inject;
 import org.apache.http.HttpStatus;
-import org.eclipse.microprofile.config.Config;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,14 +38,14 @@ public class SmartTriggersContext implements RemoteContext {
     private Logger log = LoggerFactory.getLogger(getClass());
     private TriggerEvaluator evaluator;
     private ObjectMapper mapper;
-    private final Config config;
+    private final SmallRyeConfig config;
 
     private static final String PATH = "/smart-triggers/";
     private static final Pattern PATH_ID_PATTERN =
             Pattern.compile("^" + PATH + "(.*)$", Pattern.MULTILINE);
 
     @Inject
-    SmartTriggersContext(ObjectMapper mapper, TriggerEvaluator evaluator, Config config) {
+    SmartTriggersContext(ObjectMapper mapper, TriggerEvaluator evaluator, SmallRyeConfig config) {
         this.evaluator = evaluator;
         this.mapper = mapper;
         this.config = config;

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -74,6 +74,9 @@ cryostat.agent.registration.jmx.ignore=false
 cryostat.agent.registration.jmx.use-callback-host=true
 cryostat.agent.exit.deregistration.timeout-ms=10000
 
+cryostat.agent.publish.context=
+cryostat.agent.publish.fill-strategy=
+
 cryostat.agent.harvester.period-ms=-1
 cryostat.agent.harvester.template=
 cryostat.agent.harvester.max-files=2147483647

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -75,7 +75,7 @@ cryostat.agent.registration.jmx.use-callback-host=true
 cryostat.agent.exit.deregistration.timeout-ms=10000
 
 cryostat.agent.publish.context=
-cryostat.agent.publish.fill-strategy=
+cryostat.agent.publish.fill-strategy=NONE
 
 cryostat.agent.harvester.period-ms=-1
 cryostat.agent.harvester.template=

--- a/src/test/java/io/cryostat/agent/CallbackResolverTest.java
+++ b/src/test/java/io/cryostat/agent/CallbackResolverTest.java
@@ -28,7 +28,7 @@ import java.util.stream.Collectors;
 
 import io.cryostat.agent.ConfigModule.CallbackCandidate;
 
-import org.eclipse.microprofile.config.Config;
+import io.smallrye.config.SmallRyeConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -42,7 +42,7 @@ import org.projectnessie.cel.tools.ScriptHost;
 @ExtendWith(MockitoExtension.class)
 public class CallbackResolverTest {
 
-    @Mock Config config;
+    @Mock SmallRyeConfig config;
     @Mock InetAddress addr;
     MockedStatic<InetAddress> addrMock;
     CallbackResolver resolver;

--- a/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
+++ b/src/test/java/io/cryostat/agent/insights/InsightsAgentHelperTest.java
@@ -37,7 +37,7 @@ import com.redhat.insights.agent.ClassNoticer;
 import com.redhat.insights.agent.InsightsAgentHttpClient;
 import com.redhat.insights.agent.shaded.InsightsReportController;
 import com.redhat.insights.agent.shaded.http.InsightsHttpClient;
-import org.eclipse.microprofile.config.Config;
+import io.smallrye.config.SmallRyeConfig;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
@@ -55,7 +55,7 @@ public class InsightsAgentHelperTest {
 
     @Mock Instrumentation instrumentation;
     @Mock PluginInfo pluginInfo;
-    @Mock Config config;
+    @Mock SmallRyeConfig config;
     @Mock AgentBasicReport report;
     @Mock InsightsReportController controller;
     @Captor ArgumentCaptor<AgentConfiguration> configCaptor;


### PR DESCRIPTION
Depends on cryostatio/cryostat#1258
Closes #779 
See https://github.com/cryostatio/cryostat-operator/pull/1218#issuecomment-3769791987

1. Use smallrye-config directly. This is an implementation of the microprofile-config spec, but with additional capabilities. Up to this point we have managed to use the plain microprofile-config interfaces with smallrye-config as the implementation provider, but microprofile-config is missing the ability to bind sets of configuration values with a shared prefix into a Java `Map`. This is a convenient feature in general, but essentially required for the next point:
2. Adds a configuration property `cryostat.agent.publish.context`, which is a `Map<String, String>` of additional contextual information that the Agent should pass along to Cryostat when it performs its discovery publication step (ie advertising its own presence as a connectable Target). This may be used for other purposes in the future, but for now the intended use is discussed here: https://github.com/cryostatio/cryostat-operator/pull/1218#issuecomment-3769791987 . The Cryostat Operator will set environment variables on autoconfigured Pods so that the Pod name and namespace can be passed on to Cryostat along with the self-describing nodes that the Agent publishes. See cryostatio/cryostat#1258 for the server-side PR which handles this new data.
3. Adds a configuration property `cryostat.agent.publish.fill-strategy`, which tells Cryostat what kind of context the Agent finds itself in and what kind of augmentation Cryostat should do to the nodes published by this Agent. See the Cryostat PR for a detailed explanation of the `KUBERNETES` strategy.

FIXME:
~~- using smallrye-config directly results in a build error on Java 11, since the published dependency is built with Java 17 and the class file version numbers are a mismatch. This isn't a problem before this PR since we previously used microprofile-config as the compile dependency and smallrye-config as the runtime dependency. Now that smallrye-config is compiled against too, the build sees the mismatch and fails. This reveals a problem we hadn't noticed before: Cryostat Agent is supposed to be compatible with JDK 11, but smallrye-config (at least the version we're currently using) is not as it's built with JDK 17. We either need to drop JDK 11 support in Cryostat Agent, or preferably find an older smallrye-config version or alternate microprofile-config implementation which does support JDK 11.~~ https://github.com/cryostatio/cryostat-agent/pull/789

See https://github.com/smallrye/smallrye-config/pull/1287