### PR TITLE
test(it): remove JDK version-specific stderr assertion

### DIFF
--- a/src/test/java/io/cryostat/agent/AgentDynamicAttachIT.java
+++ b/src/test/java/io/cryostat/agent/AgentDynamicAttachIT.java
@@ -78,22 +78,16 @@ class AgentDynamicAttachIT {
         stderrThread.join(1000);
         stdoutThread.join(1000);
 
-        // The agent should fail to start (verified by waitForPattern above)
+        // The agent should fail to fully start due to missing Cryostat config
         MatcherAssert.assertThat(
                 dummyOutput.toString(), Matchers.containsString("Agent startup failure"));
 
+        // but it should have logged its startup messages
+        MatcherAssert.assertThat(
+                dummyOutput.toString(),
+                Matchers.containsString("DEBUG io.cryostat.agent.Agent - Cryostat Agent version"));
+
         // The agent launcher should exit successfully after injection
         MatcherAssert.assertThat(agentExitCode, Matchers.is(0));
-
-        // On JDK 17+, the JVM prints a warning message to stderr about dynamic agent loading
-        // On JDK 11, this message may not be present, so we make this assertion optional
-        String stderr = dummyStderrBuilder.toString();
-        if (!stderr.isEmpty()) {
-            MatcherAssert.assertThat(
-                    stderr,
-                    Matchers.anyOf(
-                            Matchers.containsString("A Java agent has been loaded dynamically"),
-                            Matchers.containsString("WARNING")));
-        }
     }
 }

--- a/src/test/java/io/cryostat/agent/util/ProcessTestHelper.java
+++ b/src/test/java/io/cryostat/agent/util/ProcessTestHelper.java
@@ -42,7 +42,7 @@ public class ProcessTestHelper {
     public static Process startDummyApp(String... args) throws IOException {
         List<String> command = new ArrayList<>();
         command.add("java");
-        command.add(String.format("-D%s=%s", LOG_LEVEL_PROPERTY, "WARNING"));
+        command.add(String.format("-D%s=%s", LOG_LEVEL_PROPERTY, "DEBUG"));
         command.add("-cp");
         command.add(
                 System.getProperty(PROJECT_BUILD_TEST_OUTPUT_DIRECTORY, DEFAULT_OUTPUT_DIRECTORY));


### PR DESCRIPTION
See #813
See #818

The warning message is not printed by JDK 11, but other things in the test environment may cause the JVM to print other messages to stderr as well. Since the warning message is not actually from the Agent, and only a side-effect of the Agent being loaded in some scenarios, we don't really need to test for it. So, test for something else that is specific to the Agent instead.