### PR TITLE
feat(triggers): Call sync endpoint when triggers conclude

### DIFF
--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -358,6 +358,18 @@ public class CryostatClient {
         }
     }
 
+    public CompletableFuture<Void> syncSmartTrigger(String id) {
+        HttpPost req =
+                new HttpPost(
+                        baseUri.resolve(
+                                "/api/beta/targets/" + jvmId + "/smart_triggers/sync/" + id));
+        log.trace("{}", req);
+        return supply(req, (res) -> logResponse(req, res))
+                .thenApply(res -> assertOkStatus(req, res))
+                .whenComplete((v, t) -> req.reset())
+                .thenApply(res -> null);
+    }
+
     public CompletableFuture<Void> pushHeapDump(Path heapDump, String requestId)
             throws IOException, IllegalArgumentException {
         Instant start = Instant.now();

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -44,6 +44,7 @@ import io.cryostat.agent.model.DiscoveryNode;
 import io.cryostat.agent.model.PluginInfo;
 import io.cryostat.agent.model.RegistrationInfo;
 import io.cryostat.agent.model.ServerHealth;
+import io.cryostat.agent.triggers.TriggerEvaluator.SmartTriggerUpdate;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -358,16 +359,23 @@ public class CryostatClient {
         }
     }
 
-    public CompletableFuture<Void> syncSmartTrigger(String id) {
-        HttpPost req =
-                new HttpPost(
-                        baseUri.resolve(
-                                "/api/beta/targets/" + jvmId + "/smart_triggers/sync/" + id));
-        log.trace("{}", req);
-        return supply(req, (res) -> logResponse(req, res))
-                .thenApply(res -> assertOkStatus(req, res))
-                .whenComplete((v, t) -> req.reset())
-                .thenApply(res -> null);
+    public CompletableFuture<Void> syncSmartTrigger(SmartTriggerUpdate update) {
+        try {
+            HttpPost req =
+                    new HttpPost(
+                            baseUri.resolve(
+                                    "/api/beta/targets/" + jvmId + "/smart_triggers/sync/"));
+            req.setEntity(
+                    new StringEntity(
+                            mapper.writeValueAsString(update), ContentType.APPLICATION_JSON));
+            log.trace("Sending Smart Trigger Sync Request: {}", req);
+            return supply(req, (res) -> logResponse(req, res))
+                    .thenApply(res -> assertOkStatus(req, res))
+                    .whenComplete((v, t) -> req.reset())
+                    .thenApply(res -> null);
+        } catch (JsonProcessingException e) {
+            return CompletableFuture.failedFuture(e);
+        }
     }
 
     public CompletableFuture<Void> pushHeapDump(Path heapDump, String requestId)

--- a/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import io.cryostat.agent.CryostatClient;
 import io.cryostat.agent.FlightRecorderHelper;
 import io.cryostat.agent.harvest.Harvester;
 import io.cryostat.agent.model.MBeanInfo;
@@ -60,6 +61,7 @@ public class TriggerEvaluator {
     private final ConcurrentHashMap<String, SmartTrigger> triggers = new ConcurrentHashMap<>();
     private Future<?> task;
     private final Logger log = LoggerFactory.getLogger(getClass());
+    private final CryostatClient client;
 
     @SuppressFBWarnings("EI_EXPOSE_REP2")
     public TriggerEvaluator(
@@ -69,7 +71,8 @@ public class TriggerEvaluator {
             TriggerParser parser,
             FlightRecorderHelper flightRecorderHelper,
             Harvester harvester,
-            long evaluationPeriodMs) {
+            long evaluationPeriodMs,
+            CryostatClient client) {
         this.scheduler = scheduler;
         this.definitions = Collections.unmodifiableList(definitions);
         this.parser = parser;
@@ -77,6 +80,7 @@ public class TriggerEvaluator {
         this.flightRecorderHelper = flightRecorderHelper;
         this.harvester = harvester;
         this.evaluationPeriodMs = evaluationPeriodMs;
+        this.client = client;
     }
 
     public void start(String args) {
@@ -174,6 +178,7 @@ public class TriggerEvaluator {
                         if (t.isSimple() && evaluateTriggerConstraint(t, t.getTargetDuration())) {
                             log.trace("Trigger {} satisfied, starting recording...", t);
                             startRecording(t);
+                            client.syncSmartTrigger(t.getID());
                         } else if (!t.isSimple()) {
                             if (evaluateTriggerConstraint(t, Duration.ZERO)) {
                                 // Condition was met, set the state accordingly
@@ -192,6 +197,7 @@ public class TriggerEvaluator {
                         if (evaluateTriggerConstraint(t, Duration.ofMillis(difference))) {
                             log.trace("Trigger {} satisfied, completing...", t);
                             startRecording(t);
+                            client.syncSmartTrigger(t.getID());
                         } else if (evaluateTriggerConstraint(t, Duration.ZERO)) {
                             log.trace("Trigger {} satisfied, waiting for duration...", t);
                         } else {

--- a/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerEvaluator.java
@@ -178,7 +178,11 @@ public class TriggerEvaluator {
                         if (t.isSimple() && evaluateTriggerConstraint(t, t.getTargetDuration())) {
                             log.trace("Trigger {} satisfied, starting recording...", t);
                             startRecording(t);
-                            client.syncSmartTrigger(t.getID());
+                            client.syncSmartTrigger(
+                                    new SmartTriggerUpdate(
+                                            Collections.emptyList(),
+                                            List.of(t.getID()),
+                                            Collections.emptyList()));
                         } else if (!t.isSimple()) {
                             if (evaluateTriggerConstraint(t, Duration.ZERO)) {
                                 // Condition was met, set the state accordingly
@@ -197,7 +201,11 @@ public class TriggerEvaluator {
                         if (evaluateTriggerConstraint(t, Duration.ofMillis(difference))) {
                             log.trace("Trigger {} satisfied, completing...", t);
                             startRecording(t);
-                            client.syncSmartTrigger(t.getID());
+                            client.syncSmartTrigger(
+                                    new SmartTriggerUpdate(
+                                            Collections.emptyList(),
+                                            List.of(t.getID()),
+                                            Collections.emptyList()));
                         } else if (evaluateTriggerConstraint(t, Duration.ZERO)) {
                             log.trace("Trigger {} satisfied, waiting for duration...", t);
                         } else {
@@ -312,5 +320,29 @@ public class TriggerEvaluator {
 
     public List<SmartTrigger> getDefinitions() {
         return new ArrayList<SmartTrigger>(triggers.values());
+    }
+
+    public static class SmartTriggerUpdate {
+        List<String> addedTriggers;
+        List<String> removedTriggers;
+        List<String> updatedTriggers;
+
+        public SmartTriggerUpdate(List<String> added, List<String> removed, List<String> updated) {
+            this.addedTriggers = new ArrayList<String>(added);
+            this.removedTriggers = new ArrayList<String>(removed);
+            this.updatedTriggers = new ArrayList<String>(updated);
+        }
+
+        public List<String> getAddedTriggers() {
+            return Collections.unmodifiableList(this.addedTriggers);
+        }
+
+        public List<String> getRemovedTriggers() {
+            return Collections.unmodifiableList(this.removedTriggers);
+        }
+
+        public List<String> getUpdatedTriggers() {
+            return Collections.unmodifiableList(this.updatedTriggers);
+        }
     }
 }

--- a/src/main/java/io/cryostat/agent/triggers/TriggerModule.java
+++ b/src/main/java/io/cryostat/agent/triggers/TriggerModule.java
@@ -25,6 +25,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.cryostat.agent.ConfigModule;
+import io.cryostat.agent.CryostatClient;
 import io.cryostat.agent.FlightRecorderHelper;
 import io.cryostat.agent.harvest.Harvester;
 
@@ -63,8 +64,16 @@ public abstract class TriggerModule {
             FlightRecorderHelper helper,
             Harvester harvester,
             @Named(ConfigModule.CRYOSTAT_AGENT_SMART_TRIGGER_EVALUATION_PERIOD_MS)
-                    long evaluationPeriodMs) {
+                    long evaluationPeriodMs,
+            CryostatClient client) {
         return new TriggerEvaluator(
-                scheduler, scriptHost, definitions, parser, helper, harvester, evaluationPeriodMs);
+                scheduler,
+                scriptHost,
+                definitions,
+                parser,
+                helper,
+                harvester,
+                evaluationPeriodMs,
+                client);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/cryostatio/cryostat/issues/1329
Related to: https://github.com/cryostatio/cryostat/pull/1357
Depends on: https://github.com/cryostatio/cryostat/pull/1357

Adds support for the new /api/beta/targets/jvmId/smart_triggers/sync/id endpoint in the server. Calls this endpoint to sync the recording and smart trigger state when smart triggers conclude and start recordings.