### PR TITLE
feat(app-name): auto-detect own app name

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ prefer. This can also be passed as a dynamic attachment argument when starting t
 Below is a list of configuration properties that can be used to influence how `cryostat-agent` runs
 and how it advertises itself to a Cryostat server instance. Properties that require configuration are indicated with a checked box.
 
+- [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. If not explicitly set, the agent will automatically determine the application name from available runtime sources in the following priority order:
+  1. Explicit configuration via this property (highest priority)
+  2. `sun.java.command` system property (extracts main class or JAR name)
+  3. `JAVA_MAIN_CLASS` environment variable
+  4. Falls back to `cryostat-agent` if none are available
+
+  Users can override automatic detection by explicitly setting this property (e.g., via Kubernetes Downward API to use Pod/Deployment name).
 - [x] `cryostat.agent.baseuri` [`java.net.URI`]: the URL location of the Cryostat server backend that this agent advertises itself to.
 - [ ] `cryostat.agent.baseuri-range` [`String`]: a `String` representing the `io.cryostat.agent.ConfigModule.UriRange` enum level that restricts the acceptable hosts specified in the `cryostat.agent.baseuri` property. This is used to control the server locations that this Cryostat Agent instance is willing to register itself with. Default `dns_local`, which means any IP or hostname that is or resolves to `localhost`, a link-local IP address, an IP address from a private range block, or a hostname ending in `.local` will be accepted. If a `cryostat.agent.baseuri` is specified with a host outside of this range then the Agent will refuse to start. Acceptable values are: `loopback`, `link_local`, `site_local`, `dns_local`, and `public`. Each higher/more relaxed level implies that each lower level is also acceptable.
 - [x] `cryostat.agent.callback` [`java.net.URI`]: a URL pointing back to this agent, ex. `"https://12.34.56.78:1234/"`. Cryostat will use this URL to perform health checks and request updates from the agent. This reflects the externally-visible IP address/hostname and port where this application and agent can be found.
@@ -237,7 +244,6 @@ and how it advertises itself to a Cryostat server instance. Properties that requ
 - [ ] `cryostat.agent.webserver.credentials.user` [`String`]: the username used for `Basic` authorization on the embedded webserver. Default `user`.
 - [ ] `cryostat.agent.webserver.credentials.pass.length` [`int`]: the length of the generated password used for `Basic` authorization on the embedded webserver. Default `24`.
 - [ ] `cryostat.agent.webserver.credentials.pass.hash-function` [`String`]: the name of the hash function to use when generating passwords. Default `SHA-256`.
-- [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. Default `cryostat-agent`.
 - [ ] `cryostat.agent.app.jmx.port` [`int`]: the JMX RMI port that the application is listening on. The default is to attempt to determine this from the `com.sun.management.jmxremote.port` system property.
 - [ ] `cryostat.agent.registration.retry-ms` [`long`]: the duration in milliseconds between attempts to register with the Cryostat server. Default `5000`.
 - [ ] `cryostat.agent.registration.jmx.ignore` [`boolean`]: if the Agent detects that the host JVM has its JMX server enabled, then setting this property to `true` will cause the Agent to ignore the JMX server and not publish a JMX Service URL after registering with the Cryostat server. Default `false`.

--- a/README.md
+++ b/README.md
@@ -181,9 +181,10 @@ and how it advertises itself to a Cryostat server instance. Properties that requ
 
 - [ ] `cryostat.agent.app.name` [`String`]: a human-friendly name for this application. If not explicitly set, the agent will automatically determine the application name from available runtime sources in the following priority order:
   1. Explicit configuration via this property (highest priority)
-  2. `sun.java.command` system property (extracts main class or JAR name)
-  3. `JAVA_MAIN_CLASS` environment variable
-  4. Falls back to `cryostat-agent` if none are available
+  2. `APP_NAME`, `SERVICE_NAME`, or `APPLICATION_NAME` environment variables
+  3. `sun.java.command` system property
+  4. `JAVA_MAIN_CLASS` environment variable
+  5. Falls back to `cryostat-agent` if none are available
 
   Users can override automatic detection by explicitly setting this property (e.g., via Kubernetes Downward API to use Pod/Deployment name).
 - [x] `cryostat.agent.baseuri` [`java.net.URI`]: the URL location of the Cryostat server backend that this agent advertises itself to.

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -52,6 +52,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import io.cryostat.agent.mxbean.CryostatAgentMXBeanImpl;
+import io.cryostat.agent.util.AppNameResolver;
 import io.cryostat.agent.util.ResourcesUtil;
 import io.cryostat.libcryostat.net.CryostatAgentMXBean;
 
@@ -890,8 +891,9 @@ public abstract class ConfigModule {
     @Provides
     @Singleton
     @Named(CRYOSTAT_AGENT_APP_NAME)
-    public static String provideCryostatAgentAppName(SmallRyeConfig config) {
-        return config.getValue(CRYOSTAT_AGENT_APP_NAME, String.class);
+    public static String provideCryostatAgentAppName(
+            SmallRyeConfig config, AppNameResolver resolver) {
+        return resolver.resolveAppName(config);
     }
 
     @Provides

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -78,6 +78,7 @@ import io.cryostat.agent.harvest.HarvestModule;
 import io.cryostat.agent.remote.RemoteContext;
 import io.cryostat.agent.remote.RemoteModule;
 import io.cryostat.agent.triggers.TriggerModule;
+import io.cryostat.agent.util.AppNameResolver;
 import io.cryostat.libcryostat.JvmIdentifier;
 import io.cryostat.libcryostat.net.IDException;
 
@@ -836,6 +837,7 @@ public abstract class MainModule {
             CryostatClient cryostat,
             CallbackResolver callbackResolver,
             WebServer webServer,
+            AppNameResolver appNameResolver,
             @Named(ConfigModule.CRYOSTAT_AGENT_INSTANCE_ID) String instanceId,
             @Named(JVM_ID) String jvmId,
             @Named(ConfigModule.CRYOSTAT_AGENT_APP_NAME) String appName,
@@ -866,6 +868,7 @@ public abstract class MainModule {
                 cryostat,
                 callbackResolver,
                 webServer,
+                appNameResolver,
                 instanceId,
                 jvmId,
                 appName,

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -37,6 +37,7 @@ import java.util.stream.Collectors;
 import io.cryostat.agent.VersionInfo.Semver;
 import io.cryostat.agent.model.DiscoveryNode;
 import io.cryostat.agent.model.PluginInfo;
+import io.cryostat.agent.util.AppNameResolver;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.net.URIBuilder;
@@ -54,6 +55,7 @@ public class Registration {
     private final CryostatClient cryostat;
     private final CallbackResolver callbackResolver;
     private final WebServer webServer;
+    private final AppNameResolver appNameResolver;
     private final String instanceId;
     private final String jvmId;
     private final String appName;
@@ -76,6 +78,7 @@ public class Registration {
             CryostatClient cryostat,
             CallbackResolver callbackResolver,
             WebServer webServer,
+            io.cryostat.agent.util.AppNameResolver appNameResolver,
             String instanceId,
             String jvmId,
             String appName,
@@ -90,6 +93,7 @@ public class Registration {
         this.cryostat = cryostat;
         this.callbackResolver = callbackResolver;
         this.webServer = webServer;
+        this.appNameResolver = appNameResolver;
         this.instanceId = instanceId;
         this.jvmId = jvmId;
         this.appName = appName;
@@ -308,7 +312,10 @@ public class Registration {
         Set<DiscoveryNode> discoveryNodes = new HashSet<>();
 
         long pid = ProcessHandle.current().pid();
-        String javaMain = System.getProperty("sun.java.command", System.getenv("JAVA_MAIN_CLASS"));
+        String javaMain = appNameResolver.extractFromJavaCommand();
+        if (StringUtils.isBlank(javaMain)) {
+            javaMain = System.getenv("JAVA_MAIN_CLASS");
+        }
         if (StringUtils.isBlank(javaMain)) {
             log.warn("Unable to determine application mainclass");
             javaMain = null;

--- a/src/main/java/io/cryostat/agent/util/AppNameResolver.java
+++ b/src/main/java/io/cryostat/agent/util/AppNameResolver.java
@@ -1,0 +1,173 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.util;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Optional;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import io.cryostat.agent.ConfigModule;
+
+import io.smallrye.config.SmallRyeConfig;
+import org.apache.commons.lang3.StringUtils;
+
+/**
+ * Utility class for resolving the application name from various sources.
+ *
+ * <p>Resolution priority order:
+ *
+ * <ol>
+ *   <li>Explicit configuration property ({@code cryostat.agent.app.name})
+ *   <li>System property {@code sun.java.command} (extracts main class or JAR name)
+ *   <li>Environment variable {@code JAVA_MAIN_CLASS}
+ *   <li>Fallback to default constant "cryostat-agent"
+ * </ol>
+ */
+@Singleton
+public class AppNameResolver {
+
+    private static final String DEFAULT_APP_NAME = "cryostat-agent";
+    private static final String SUN_JAVA_COMMAND_PROPERTY = "sun.java.command";
+    private static final String JAVA_MAIN_CLASS_ENV = "JAVA_MAIN_CLASS";
+    private static final String JAR_FLAG = "-jar";
+
+    @Inject
+    public AppNameResolver() {}
+
+    /**
+     * Resolves the application name using the configured priority order.
+     *
+     * @param config the SmallRye configuration instance
+     * @return the resolved application name, never null or blank
+     */
+    public String resolveAppName(SmallRyeConfig config) {
+        Optional<String> configured =
+                config.getOptionalValue(ConfigModule.CRYOSTAT_AGENT_APP_NAME, String.class);
+        if (configured.isPresent() && !StringUtils.isBlank(configured.get())) {
+            return configured.get().trim();
+        }
+
+        String fromCommand = extractFromJavaCommand();
+        if (!StringUtils.isBlank(fromCommand)) {
+            return fromCommand;
+        }
+
+        String fromEnv = System.getenv(JAVA_MAIN_CLASS_ENV);
+        if (!StringUtils.isBlank(fromEnv)) {
+            return fromEnv.trim();
+        }
+
+        return DEFAULT_APP_NAME;
+    }
+
+    /**
+     * Extracts application name from the sun.java.command system property.
+     *
+     * @return the extracted application name, or null if unable to extract
+     */
+    public String extractFromJavaCommand() {
+        String command = System.getProperty(SUN_JAVA_COMMAND_PROPERTY);
+        if (StringUtils.isBlank(command)) {
+            return null;
+        }
+
+        command = command.trim();
+
+        if (command.contains(JAR_FLAG)) {
+            return extractJarName(command);
+        }
+
+        return extractMainClass(command);
+    }
+
+    /**
+     * Extracts the JAR name from a command line containing "-jar".
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>"-jar /path/to/my-app.jar" -> "my-app.jar"
+     *   <li>"-jar app.jar arg1 arg2" -> "app.jar"
+     *   <li>"java -jar /opt/application.jar" -> "application.jar"
+     * </ul>
+     *
+     * @param command the command line string containing "-jar"
+     * @return the JAR filename with extension, or null if unable to extract
+     */
+    String extractJarName(String command) {
+        String[] tokens = command.split("\\s+");
+
+        for (int i = 0; i < tokens.length - 1; i++) {
+            if (JAR_FLAG.equals(tokens[i])) {
+                String jarPath = tokens[i + 1];
+                if (StringUtils.isBlank(jarPath)) {
+                    return null;
+                }
+
+                Path path = Paths.get(jarPath);
+                Path fileNamePath = path.getFileName();
+                if (fileNamePath == null) {
+                    return null;
+                }
+                String fileName = fileNamePath.toString();
+
+                return StringUtils.isBlank(fileName) ? null : fileName;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Extracts the main class name from a command line.
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>"com.example.MyApp arg1 arg2" -> "com.example.MyApp"
+     *   <li>"org.springframework.boot.loader.JarLauncher" ->
+     *       "org.springframework.boot.loader.JarLauncher"
+     *   <li>"MyApp" -> "MyApp"
+     * </ul>
+     *
+     * @param command the command line string
+     * @return the fully qualified class name, or null if unable to extract
+     */
+    String extractMainClass(String command) {
+        if (StringUtils.isBlank(command)) {
+            return null;
+        }
+
+        String[] tokens = command.split("\\s+");
+        if (tokens.length == 0) {
+            return null;
+        }
+
+        String mainClass = tokens[0].trim();
+        if (StringUtils.isBlank(mainClass)) {
+            return null;
+        }
+
+        if (mainClass.equals(".") || mainClass.endsWith(".")) {
+            return null;
+        }
+
+        return mainClass;
+    }
+}

--- a/src/main/java/io/cryostat/agent/util/AppNameResolver.java
+++ b/src/main/java/io/cryostat/agent/util/AppNameResolver.java
@@ -45,22 +45,52 @@ public class AppNameResolver {
     private static final String DEFAULT_APP_NAME = "cryostat-agent";
     private static final String SUN_JAVA_COMMAND_PROPERTY = "sun.java.command";
     private static final String JAVA_MAIN_CLASS_ENV = "JAVA_MAIN_CLASS";
+    private static final String APP_NAME_ENV = "APP_NAME";
+    private static final String SERVICE_NAME_ENV = "SERVICE_NAME";
+    private static final String APPLICATION_NAME_ENV = "APPLICATION_NAME";
     private static final String JAR_FLAG = "-jar";
+
+    private volatile String cachedAppName;
 
     @Inject
     public AppNameResolver() {}
 
     /**
-     * Resolves the application name using the configured priority order.
+     * Resolves the application name.
      *
      * @param config the SmallRye configuration instance
      * @return the resolved application name, never null or blank
      */
     public String resolveAppName(SmallRyeConfig config) {
+        String cached = cachedAppName;
+        if (cached != null) {
+            return cached;
+        }
+        String resolved = performResolution(config);
+        cachedAppName = resolved;
+        return resolved;
+    }
+
+    private String performResolution(SmallRyeConfig config) {
         Optional<String> configured =
                 config.getOptionalValue(ConfigModule.CRYOSTAT_AGENT_APP_NAME, String.class);
         if (configured.isPresent() && !StringUtils.isBlank(configured.get())) {
             return configured.get().trim();
+        }
+
+        String appName = System.getenv(APP_NAME_ENV);
+        if (!StringUtils.isBlank(appName)) {
+            return appName.trim();
+        }
+
+        String serviceName = System.getenv(SERVICE_NAME_ENV);
+        if (!StringUtils.isBlank(serviceName)) {
+            return serviceName.trim();
+        }
+
+        String applicationName = System.getenv(APPLICATION_NAME_ENV);
+        if (!StringUtils.isBlank(applicationName)) {
+            return applicationName.trim();
         }
 
         String fromCommand = extractFromJavaCommand();

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -1,4 +1,5 @@
-cryostat.agent.app.name=cryostat-agent
+cryostat.agent.app.name=
+
 cryostat.agent.baseuri-range=dns_local
 cryostat.agent.baseuri=
 

--- a/src/test/java/io/cryostat/agent/util/AppNameResolverTest.java
+++ b/src/test/java/io/cryostat/agent/util/AppNameResolverTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AppNameResolverTest {
+
+    AppNameResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        resolver = new AppNameResolver();
+    }
+
+    @Test
+    void testExtractMainClassFromSimpleClassName() {
+        String result = resolver.extractMainClass("MyApp");
+        assertEquals("MyApp", result);
+    }
+
+    @Test
+    void testExtractMainClassFromFullyQualifiedClassName() {
+        String result = resolver.extractMainClass("com.example.MyApp");
+        assertEquals("com.example.MyApp", result);
+    }
+
+    @Test
+    void testExtractMainClassFromClassNameWithArguments() {
+        String result = resolver.extractMainClass("com.example.MyApp arg1 arg2 arg3");
+        assertEquals("com.example.MyApp", result);
+    }
+
+    @Test
+    void testExtractMainClassFromSpringBootLoader() {
+        String result =
+                resolver.extractMainClass(
+                        "org.springframework.boot.loader.JarLauncher"
+                                + " --spring.profiles.active=prod");
+        assertEquals("org.springframework.boot.loader.JarLauncher", result);
+    }
+
+    @Test
+    void testExtractMainClassFromBlankString() {
+        String result = resolver.extractMainClass("");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractMainClassFromNull() {
+        String result = resolver.extractMainClass(null);
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractMainClassFromWhitespaceOnly() {
+        String result = resolver.extractMainClass("   ");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractJarNameFromSimpleJarPath() {
+        String result = resolver.extractJarName("-jar myapp.jar");
+        assertEquals("myapp.jar", result);
+    }
+
+    @Test
+    void testExtractJarNameFromAbsolutePath() {
+        String result = resolver.extractJarName("-jar /opt/applications/my-application.jar");
+        assertEquals("my-application.jar", result);
+    }
+
+    @Test
+    void testExtractJarNameFromRelativePath() {
+        String result = resolver.extractJarName("-jar ./target/app.jar");
+        assertEquals("app.jar", result);
+    }
+
+    @Test
+    void testExtractJarNameWithArguments() {
+        String result =
+                resolver.extractJarName("-jar /path/to/service.jar --server.port=8080 --debug");
+        assertEquals("service.jar", result);
+    }
+
+    @Test
+    void testExtractJarNameFromJavaCommand() {
+        String result = resolver.extractJarName("java -Xmx512m -jar /opt/myapp.jar --config=prod");
+        assertEquals("myapp.jar", result);
+    }
+
+    @Test
+    void testExtractJarNameWithoutExtension() {
+        String result = resolver.extractJarName("-jar /path/to/application");
+        assertEquals("application", result);
+    }
+
+    @Test
+    void testExtractJarNameWithUppercaseExtension() {
+        String result = resolver.extractJarName("-jar MyApp.JAR");
+        assertEquals("MyApp.JAR", result);
+    }
+
+    @Test
+    void testExtractJarNameWithMixedCaseExtension() {
+        String result = resolver.extractJarName("-jar MyApp.JaR");
+        assertEquals("MyApp.JaR", result);
+    }
+
+    @Test
+    void testExtractJarNameWhenNoJarFlag() {
+        String result = resolver.extractJarName("com.example.MyApp");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractJarNameWhenJarFlagIsLast() {
+        String result = resolver.extractJarName("java -Xmx512m -jar");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractJarNameWhenJarPathIsBlank() {
+        String result = resolver.extractJarName("-jar    ");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractFromJavaCommandWithMainClass() {
+        String originalProperty = System.getProperty("sun.java.command");
+        try {
+            System.setProperty("sun.java.command", "com.example.MyApplication arg1 arg2");
+            String result = resolver.extractFromJavaCommand();
+            assertEquals("com.example.MyApplication", result);
+        } finally {
+            if (originalProperty != null) {
+                System.setProperty("sun.java.command", originalProperty);
+            } else {
+                System.clearProperty("sun.java.command");
+            }
+        }
+    }
+
+    @Test
+    void testExtractFromJavaCommandWithJar() {
+        String originalProperty = System.getProperty("sun.java.command");
+        try {
+            System.setProperty("sun.java.command", "-jar /opt/my-service.jar --port=8080");
+            String result = resolver.extractFromJavaCommand();
+            assertEquals("my-service.jar", result);
+        } finally {
+            if (originalProperty != null) {
+                System.setProperty("sun.java.command", originalProperty);
+            } else {
+                System.clearProperty("sun.java.command");
+            }
+        }
+    }
+
+    @Test
+    void testExtractFromJavaCommandWhenPropertyNotSet() {
+        String originalProperty = System.getProperty("sun.java.command");
+        try {
+            System.clearProperty("sun.java.command");
+            String result = resolver.extractFromJavaCommand();
+            assertNull(result);
+        } finally {
+            if (originalProperty != null) {
+                System.setProperty("sun.java.command", originalProperty);
+            }
+        }
+    }
+
+    @Test
+    void testExtractFromJavaCommandWhenPropertyIsBlank() {
+        String originalProperty = System.getProperty("sun.java.command");
+        try {
+            System.setProperty("sun.java.command", "   ");
+            String result = resolver.extractFromJavaCommand();
+            assertNull(result);
+        } finally {
+            if (originalProperty != null) {
+                System.setProperty("sun.java.command", originalProperty);
+            } else {
+                System.clearProperty("sun.java.command");
+            }
+        }
+    }
+
+    @Test
+    void testExtractMainClassWithMultipleSpaces() {
+        String result = resolver.extractMainClass("com.example.App    arg1    arg2");
+        assertEquals("com.example.App", result);
+    }
+
+    @Test
+    void testExtractMainClassWithTabs() {
+        String result = resolver.extractMainClass("com.example.App\targ1\targ2");
+        assertEquals("com.example.App", result);
+    }
+
+    @Test
+    void testExtractJarNameWithComplexPath() {
+        String result =
+                resolver.extractJarName("-jar /var/lib/apps/production/v1.2.3/my-app-1.2.3.jar");
+        assertEquals("my-app-1.2.3.jar", result);
+    }
+
+    @Test
+    void testExtractMainClassEndsWithDot() {
+        String result = resolver.extractMainClass("com.example.");
+        assertNull(result);
+    }
+
+    @Test
+    void testExtractMainClassSingleDot() {
+        String result = resolver.extractMainClass(".");
+        assertNull(result);
+    }
+}


### PR DESCRIPTION
Related to #839

Further enhancement to the automatic randomized Realm name suffix and randomized webserver port. Automatic detection of the Agent's app.name property, which appears in the Cryostat API as the target node's name, and in the Topology view or Target context selectors. Prior to this change, Cryostat Agent instances deployed by autoconfiguration in k8s environments would have the app name automatically set to the Pod name via Downward API, but other Agent instances would default to a hardcoded `cryostat-agent` string value. For the Cryostat Local case with cryostatio/cryostat-agent#839 watch mode this is particularly unhelpful as every detected target appears with the same name and the user has to do some deeper inspection to distinguish them.
