### PR TITLE
fix(http-client): use thread-safe connection pool

### DIFF
--- a/src/main/java/io/cryostat/agent/Agent.java
+++ b/src/main/java/io/cryostat/agent/Agent.java
@@ -272,6 +272,7 @@ public class Agent implements Callable<Integer>, Consumer<AgentArgs> {
                             case REFRESHING:
                             case REFRESHED:
                             case PUBLISHED:
+                            case COOLDOWN:
                                 log.debug("Registration state: {}", evt.state);
                                 break;
                             default:

--- a/src/main/java/io/cryostat/agent/ConfigModule.java
+++ b/src/main/java/io/cryostat/agent/ConfigModule.java
@@ -271,6 +271,11 @@ public abstract class ConfigModule {
     public static final String CRYOSTAT_AGENT_CREDENTIAL_CLEANUP_MAX_RETRIES =
             "cryostat.agent.credential.cleanup.max-retries";
 
+    public static final String CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_TOTAL =
+            "cryostat.agent.webclient.connection-pool.max-total";
+    public static final String CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_PER_ROUTE =
+            "cryostat.agent.webclient.connection-pool.max-per-route";
+
     @Provides
     @Singleton
     public static SmallRyeConfig provideConfig() {
@@ -1165,6 +1170,20 @@ public abstract class ConfigModule {
     @Named(CRYOSTAT_AGENT_CREDENTIAL_CLEANUP_MAX_RETRIES)
     public static int provideCryostatAgentCredentialCleanupMaxRetries(SmallRyeConfig config) {
         return config.getValue(CRYOSTAT_AGENT_CREDENTIAL_CLEANUP_MAX_RETRIES, int.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_TOTAL)
+    public static int provideConnectionPoolMaxTotal(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_TOTAL, int.class);
+    }
+
+    @Provides
+    @Singleton
+    @Named(CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_PER_ROUTE)
+    public static int provideConnectionPoolMaxPerRoute(SmallRyeConfig config) {
+        return config.getValue(CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_PER_ROUTE, int.class);
     }
 
     public enum URIRange {

--- a/src/main/java/io/cryostat/agent/MainModule.java
+++ b/src/main/java/io/cryostat/agent/MainModule.java
@@ -100,8 +100,7 @@ import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.DefaultHttpRequestRetryStrategy;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
-import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
@@ -661,7 +660,10 @@ public abstract class MainModule {
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_TIMEOUT_MS) int responseTimeout,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_COUNT) int retryCount,
             @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_RESPONSE_RETRY_TIME) int retryTime,
-            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_TLS_REQUIRED) boolean tlsRequired) {
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_TLS_REQUIRED) boolean tlsRequired,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_TOTAL) int maxTotal,
+            @Named(ConfigModule.CRYOSTAT_AGENT_WEBCLIENT_CONNECTION_POOL_MAX_PER_ROUTE)
+                    int maxPerRoute) {
         SSLConnectionSocketFactory sslSocketFactory =
                 new SSLConnectionSocketFactory(
                         sslContext,
@@ -675,8 +677,10 @@ public abstract class MainModule {
         if (!tlsRequired) {
             socketFactoryRegistryBuilder.register("http", new PlainConnectionSocketFactory());
         }
-        HttpClientConnectionManager connMan =
-                new BasicHttpClientConnectionManager(socketFactoryRegistryBuilder.build());
+        PoolingHttpClientConnectionManager connMan =
+                new PoolingHttpClientConnectionManager(socketFactoryRegistryBuilder.build());
+        connMan.setMaxTotal(maxTotal);
+        connMan.setDefaultMaxPerRoute(maxPerRoute);
         HttpClientBuilder builder =
                 HttpClients.custom()
                         .setConnectionManager(connMan)

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -76,8 +76,8 @@ cryostat.agent.registration.jmx.use-callback-host=true
 cryostat.agent.registration.max-backoff-ms=300000
 cryostat.agent.registration.backoff-multiplier=2.0
 cryostat.agent.registration.circuit-breaker-threshold=10
-cryostat.agent.registration.circuit-breaker-duration=PT5M
-cryostat.agent.registration.min-cooldown-ms=300000
+cryostat.agent.registration.circuit-breaker-duration=PT30S
+cryostat.agent.registration.min-cooldown-ms=30000
 cryostat.agent.exit.deregistration.timeout-ms=10000
 
 cryostat.agent.publish.context=

--- a/src/main/resources/META-INF/microprofile-config.properties
+++ b/src/main/resources/META-INF/microprofile-config.properties
@@ -101,4 +101,7 @@ cryostat.agent.smart-trigger.evaluation.period-ms=1000
 cryostat.agent.credential.cleanup.interval=PT1M
 cryostat.agent.credential.cleanup.max-retries=5
 
+cryostat.agent.webclient.connection-pool.max-total=10
+cryostat.agent.webclient.connection-pool.max-per-route=5
+
 cryostat.agent.fleet-sampling-ratio=Infinity


### PR DESCRIPTION
See #851

BasicHttpClientConnectionManager is NOT thread-safe and maintains only a single connection. It's designed for single-threaded use only, but the Agent uses a ScheduledExecutorService with 3 worker threads. Misuse of the connection manager by different threads leads to an IllegalStateException in the HTTP client the Agent uses to send requests to Cryostat.

This HTTP client failure results in the Agent entering a degraded cooldown state where it believes it's unable to register with the Cryostat server due to a server-side failure, which also results in it rejecting connection requests to its own WebServer. The cooldown period is too long and Cryostat repeatedly fails to ping the Agent because it's in cooldown for too long, resulting in Cryostat eventually pruning the plugin.

This patch does two things:
1. reduces the cooldown period. The Agent should prevent itself from flooding Cryostat with re-registration requests, but it should also become ready to accept pings from Cryostat more quickly so that Cryostat can recognize that it is still alive and reachable.
2. uses a pooling HTTP connection manager which is thread safe, preventing the Agent-side failure which triggers the degraded state to begin with.

```
2026-04-30 15:33:35:297 +0000 [cryostat-agent-worker-2] ERROR io.cryostat.agent.Registration - Registration failure (attempt 1, circuit state: CLOSED, cooldown: PT5M)
java.util.concurrent.CompletionException: java.lang.IllegalStateException: Connection 10.217.0.205:38574<->10.217.5.209:8282 is still allocated
	at java.base/java.util.concurrent.CompletableFuture.encodeThrowable(CompletableFuture.java:315)
	at java.base/java.util.concurrent.CompletableFuture.completeThrowable(CompletableFuture.java:320)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1770)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:304)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
Caused by: java.lang.IllegalStateException: Connection 10.217.0.205:38574<->10.217.5.209:8282 is still allocated
	at io.cryostat.agent.shaded.org.apache.shaded.hc.core5.util.Asserts.check(Asserts.java:50)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.io.BasicHttpClientConnectionManager.getConnection(BasicHttpClientConnectionManager.java:389)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.io.BasicHttpClientConnectionManager$1.get(BasicHttpClientConnectionManager.java:311)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.InternalExecRuntime.acquireEndpoint(InternalExecRuntime.java:111)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ConnectExec.execute(ConnectExec.java:127)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ProtocolExec.execute(ProtocolExec.java:192)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ContentCompressionExec.execute(ContentCompressionExec.java:150)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.HttpRequestRetryExec.execute(HttpRequestRetryExec.java:113)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.RedirectExec.execute(RedirectExec.java:110)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.ExecChainElement.execute(ExecChainElement.java:51)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.InternalHttpClient.doExecute(InternalHttpClient.java:183)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:141)
	at io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.CloseableHttpClient.execute(CloseableHttpClient.java:55)
	at io.cryostat.agent.CryostatClient.executeQuiet(CryostatClient.java:553)
	at io.cryostat.agent.CryostatClient.lambda$supply$43(CryostatClient.java:548)
	at java.base/java.util.concurrent.CompletableFuture$AsyncSupply.run(CompletableFuture.java:1768)
	... 6 more
2026-04-30 15:33:35:297 +0000 [cryostat-agent-worker-1] DEBUG io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.classic.InternalHttpClient - ep-0000000000 start execution ex-0000000014
2026-04-30 15:33:35:297 +0000 [cryostat-agent-worker-2] DEBUG io.cryostat.agent.Registration - Entering cooldown for PT5M after 1 consecutive failures
2026-04-30 15:33:35:297 +0000 [cryostat-agent-worker-1] DEBUG io.cryostat.agent.shaded.org.apache.shaded.hc.client5.http.impl.io.BasicHttpClientConnectionManager - ep-0000000000 Executing exchange ex-0000000014
2026-04-30 15:33:35:297 +0000 [cryostat-agent-worker-2] DEBUG io.cryostat.agent.WebServer - Performing cleanup before cooldown
```
