### PR TITLE
fix(registration): reuse stored credentials if already in keyring

### DIFF
--- a/src/main/java/io/cryostat/agent/CredentialCleanupJob.java
+++ b/src/main/java/io/cryostat/agent/CredentialCleanupJob.java
@@ -115,6 +115,21 @@ public class CredentialCleanupJob {
                             .handle(
                                     (v, t) -> {
                                         if (t != null) {
+                                            Throwable cause = t;
+                                            while (cause.getCause() != null) {
+                                                cause = cause.getCause();
+                                            }
+                                            if (cause instanceof HttpException
+                                                    && ((HttpException) cause).statusCode()
+                                                            == 404) {
+                                                log.debug(
+                                                        "Credential {} was already deleted"
+                                                                + " remotely",
+                                                        credentialId);
+                                                retryCount.remove(credentialId);
+                                                tracker.trackDeleted(credentialId);
+                                                return null;
+                                            }
                                             log.warn(
                                                     "Failed to delete credential {} (attempt {})",
                                                     credentialId,

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -202,23 +202,30 @@ public class CryostatClient {
                                 return submitCredentials(prevId, credentials, callback);
                             });
         }
-        HttpGet req = new HttpGet(baseUri.resolve(CREDENTIALS_API_PATH + "/" + prevId));
-        log.trace("{}", req);
-        return supply(req, (res) -> logResponse(req, res))
-                .handle(
-                        (v, t) -> {
-                            if (t != null) {
-                                log.error("Failed to get credentials with ID " + prevId, t);
-                                throw new CompletionException(t);
-                            }
-                            return isOkStatus(v);
-                        })
+        return credentialExists(prevId)
                 .thenCompose(
                         exists -> {
                             if (exists) {
                                 return CompletableFuture.completedFuture(prevId);
                             }
                             return submitCredentials(prevId, credentials, callback);
+                        });
+    }
+
+    public CompletableFuture<Boolean> credentialExists(int credentialId) {
+        if (credentialId < 0) {
+            return CompletableFuture.completedFuture(false);
+        }
+        HttpGet req = new HttpGet(baseUri.resolve(CREDENTIALS_API_PATH + "/" + credentialId));
+        log.trace("{}", req);
+        return supply(req, (res) -> logResponse(req, res))
+                .handle(
+                        (v, t) -> {
+                            if (t != null) {
+                                log.error("Failed to get credentials with ID {}", credentialId, t);
+                                throw new CompletionException(t);
+                            }
+                            return isOkStatus(v);
                         })
                 .whenComplete((v, t) -> req.reset());
     }

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -26,6 +26,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -262,6 +263,10 @@ public class CryostatClient {
     private CompletableFuture<Integer> submitCredentials(
             int prevId, Credentials credentials, URI callback) {
         HttpPost req = new HttpPost(baseUri.resolve(CREDENTIALS_API_PATH));
+        byte[] passwordCopy;
+        synchronized (credentials) {
+            passwordCopy = Arrays.copyOf(credentials.pass(), credentials.pass().length);
+        }
         MultipartEntityBuilder entityBuilder =
                 MultipartEntityBuilder.create()
                         .addPart(
@@ -274,7 +279,7 @@ public class CryostatClient {
                                 FormBodyPartBuilder.create(
                                                 "password",
                                                 new ByteArrayBody(
-                                                        credentials.pass(),
+                                                        passwordCopy,
                                                         ContentType.TEXT_PLAIN,
                                                         "pass"))
                                         .build())

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -346,7 +346,8 @@ public class CryostatClient {
                             credentialTracker.trackCreated(credId);
                             return CompletableFuture.completedFuture(credId);
                         })
-                .whenComplete((v, t) -> req.reset());
+                .whenComplete((v, t) -> req.reset())
+                .whenComplete((v, t) -> Arrays.fill(passwordCopy, (byte) 0));
     }
 
     public CompletableFuture<Void> deleteCredentials(int id) {

--- a/src/main/java/io/cryostat/agent/HttpException.java
+++ b/src/main/java/io/cryostat/agent/HttpException.java
@@ -18,14 +18,23 @@ package io.cryostat.agent;
 import java.net.URI;
 
 public class HttpException extends RuntimeException {
+
+    private final int statusCode;
+
     HttpException(int statusCode, URI uri) {
         super(
                 String.format(
                         "Unexpected non-OK status code %d on API path %s",
                         statusCode, uri.toString()));
+        this.statusCode = statusCode;
     }
 
     HttpException(int statusCode, Throwable cause) {
         super(String.format("HTTP %d", statusCode), cause);
+        this.statusCode = statusCode;
+    }
+
+    public int statusCode() {
+        return statusCode;
     }
 }

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -359,76 +359,95 @@ public class Registration {
                                         return CompletableFuture.failedFuture(e);
                                     }
                                 })
-                        .handle(
-                                (plugin, t) -> {
-                                    if (plugin != null) {
-                                        boolean previouslyRegistered =
-                                                this.pluginInfo.isInitialized();
-                                        this.pluginInfo.copyFrom(plugin);
-                                        log.debug("Registered as {}", this.pluginInfo.getId());
+                        .thenCompose(
+                                plugin -> {
+                                    boolean previouslyRegistered = this.pluginInfo.isInitialized();
+                                    this.pluginInfo.copyFrom(plugin);
+                                    log.debug("Registered as {}", this.pluginInfo.getId());
 
-                                        lastSuccessfulRegistration = Instant.now();
-                                        consecutiveFailures.set(0);
+                                    lastSuccessfulRegistration = Instant.now();
+                                    consecutiveFailures.set(0);
 
-                                        if (circuitState == CircuitState.HALF_OPEN) {
-                                            log.debug("Circuit breaker transitioning to CLOSED");
-                                        }
-                                        circuitState = CircuitState.CLOSED;
-
-                                        log.debug(
-                                                "Registration successful at {}, next attempt"
-                                                        + " allowed after {}",
-                                                lastSuccessfulRegistration,
-                                                lastSuccessfulRegistration.plus(
-                                                        minCooldownDuration));
-
-                                        if (previouslyRegistered) {
-                                            notify(RegistrationEvent.State.REFRESHED);
-                                        } else {
-                                            notify(RegistrationEvent.State.REGISTERED);
-                                            tryUpdate();
-                                        }
-                                    } else if (t != null) {
-                                        this.webServer.resetCredentialId();
-                                        this.pluginInfo.clear();
-
-                                        int failures = consecutiveFailures.incrementAndGet();
-                                        long backoffMs = calculateBackoffMs();
-                                        Duration cooldown = Duration.ofMillis(backoffMs);
-
-                                        if (circuitState == CircuitState.CLOSED
-                                                && failures >= circuitBreakerThreshold) {
-                                            log.warn(
-                                                    "Circuit breaker transitioning to OPEN after {}"
-                                                            + " failures",
-                                                    failures);
-                                            circuitState = CircuitState.OPEN;
-                                            circuitOpenedAt = Instant.now();
-                                        } else if (circuitState == CircuitState.HALF_OPEN) {
-                                            log.warn("Circuit breaker transitioning back to OPEN");
-                                            circuitState = CircuitState.OPEN;
-                                            circuitOpenedAt = Instant.now();
-                                        }
-
-                                        log.error(
-                                                "Registration failure (attempt {}, circuit state:"
-                                                        + " {}, cooldown: {})",
-                                                failures,
-                                                circuitState,
-                                                cooldown,
-                                                t);
-
-                                        if (minCooldownDuration.isZero()) {
-                                            executor.schedule(
-                                                    this::tryRegister,
-                                                    backoffMs,
-                                                    TimeUnit.MILLISECONDS);
-                                        } else {
-                                            enterCooldown(cooldown);
-                                        }
+                                    if (circuitState == CircuitState.HALF_OPEN) {
+                                        log.debug("Circuit breaker transitioning to CLOSED");
                                     }
-                                    return (Void) null;
-                                });
+                                    circuitState = CircuitState.CLOSED;
+
+                                    log.debug(
+                                            "Registration successful at {}, next attempt"
+                                                    + " allowed after {}",
+                                            lastSuccessfulRegistration,
+                                            lastSuccessfulRegistration.plus(minCooldownDuration));
+
+                                    if (previouslyRegistered) {
+                                        notify(RegistrationEvent.State.REFRESHED);
+                                    } else {
+                                        notify(RegistrationEvent.State.REGISTERED);
+                                        tryUpdate();
+                                    }
+                                    return CompletableFuture.<Void>completedFuture(null);
+                                })
+                        .exceptionallyCompose(t -> handleRegistrationFailure(credentialId, t));
+    }
+
+    private CompletableFuture<Void> handleRegistrationFailure(int credentialId, Throwable t) {
+        if (credentialId < 0) {
+            return completeRegistrationFailure(t);
+        }
+        return cryostat.credentialExists(credentialId)
+                .handle(
+                        (exists, checkError) -> {
+                            if (checkError != null) {
+                                log.warn(
+                                        "Unable to verify existence of credential ID {} after"
+                                                + " registration failure. Retaining local state",
+                                        credentialId,
+                                        checkError);
+                                return false;
+                            }
+                            if (!Boolean.TRUE.equals(exists)) {
+                                this.webServer.resetCredentialId();
+                                return true;
+                            }
+                            log.debug(
+                                    "Credential ID {} still exists remotely after registration"
+                                            + " failure. Retaining local state",
+                                    credentialId);
+                            return false;
+                        })
+                .thenCompose(v -> completeRegistrationFailure(t));
+    }
+
+    private CompletableFuture<Void> completeRegistrationFailure(Throwable t) {
+        this.pluginInfo.clear();
+
+        int failures = consecutiveFailures.incrementAndGet();
+        long backoffMs = calculateBackoffMs();
+        Duration cooldown = Duration.ofMillis(backoffMs);
+
+        if (circuitState == CircuitState.CLOSED && failures >= circuitBreakerThreshold) {
+            log.warn("Circuit breaker transitioning to OPEN after {} failures", failures);
+            circuitState = CircuitState.OPEN;
+            circuitOpenedAt = Instant.now();
+        } else if (circuitState == CircuitState.HALF_OPEN) {
+            log.warn("Circuit breaker transitioning back to OPEN");
+            circuitState = CircuitState.OPEN;
+            circuitOpenedAt = Instant.now();
+        }
+
+        log.error(
+                "Registration failure (attempt {}, circuit state: {}, cooldown: {})",
+                failures,
+                circuitState,
+                cooldown,
+                t);
+
+        if (minCooldownDuration.isZero()) {
+            executor.schedule(this::tryRegister, backoffMs, TimeUnit.MILLISECONDS);
+        } else {
+            enterCooldown(cooldown);
+        }
+        return CompletableFuture.completedFuture(null);
     }
 
     private long calculateBackoffMs() {

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -359,8 +359,12 @@ public class Registration {
                                         return CompletableFuture.failedFuture(e);
                                     }
                                 })
-                        .thenCompose(
-                                plugin -> {
+                        .handle(
+                                (plugin, t) -> {
+                                    if (t != null) {
+                                        return handleRegistrationFailure(credentialId, t);
+                                    }
+
                                     boolean previouslyRegistered = this.pluginInfo.isInitialized();
                                     this.pluginInfo.copyFrom(plugin);
                                     log.debug("Registered as {}", this.pluginInfo.getId());
@@ -387,7 +391,7 @@ public class Registration {
                                     }
                                     return CompletableFuture.<Void>completedFuture(null);
                                 })
-                        .exceptionallyCompose(t -> handleRegistrationFailure(credentialId, t));
+                        .thenCompose(f -> f);
     }
 
     private CompletableFuture<Void> handleRegistrationFailure(int credentialId, Throwable t) {

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -55,6 +55,8 @@ class WebServer {
     private final Lazy<Registration> registration;
     private HttpServer http;
     private volatile int credentialId = -1;
+    private final Object credentialGenerationLock = new Object();
+    private CompletableFuture<Void> credentialGeneration;
 
     private final AgentAuthenticator agentAuthenticator;
     private final RequestLoggingFilter requestLoggingFilter;
@@ -216,26 +218,47 @@ class WebServer {
     }
 
     CompletableFuture<Void> generateCredentials(URI callback) {
-        this.credentials.regenerate();
-        return this.cryostat
-                .get()
-                .submitCredentialsIfRequired(
-                        this.credentialId, this.credentials, Objects.requireNonNull(callback))
-                .handle(
-                        (v, t) -> {
-                            this.credentials.clear();
-                            if (t != null) {
-                                this.resetCredentialId();
-                                log.error("Could not submit credentials", t);
-                                throw new CompletionException("Could not submit credentials", t);
-                            }
-                            return v;
-                        })
-                .thenAccept(
-                        i -> {
-                            this.credentialId = i;
-                            log.trace("Defined credentials with id {}", i);
-                        });
+        synchronized (credentialGenerationLock) {
+            if (this.credentialGeneration != null && !this.credentialGeneration.isDone()) {
+                log.trace("Reusing in-progress credential generation");
+                return this.credentialGeneration;
+            }
+
+            this.credentials.regenerate();
+            this.credentialGeneration =
+                    this.cryostat
+                            .get()
+                            .submitCredentialsIfRequired(
+                                    this.credentialId,
+                                    this.credentials,
+                                    Objects.requireNonNull(callback))
+                            .handle(
+                                    (v, t) -> {
+                                        this.credentials.clear();
+                                        if (t != null) {
+                                            this.resetCredentialId();
+                                            log.error("Could not submit credentials", t);
+                                            throw new CompletionException(
+                                                    "Could not submit credentials", t);
+                                        }
+                                        return v;
+                                    })
+                            .thenAccept(
+                                    i -> {
+                                        this.credentialId = i;
+                                        log.trace("Defined credentials with id {}", i);
+                                    })
+                            .whenComplete(
+                                    (v, t) -> {
+                                        synchronized (credentialGenerationLock) {
+                                            if (this.credentialGeneration != null
+                                                    && this.credentialGeneration.isDone()) {
+                                                this.credentialGeneration = null;
+                                            }
+                                        }
+                                    });
+            return this.credentialGeneration;
+        }
     }
 
     private HttpHandler wrap(HttpHandler handler) {

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -24,7 +24,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -294,8 +293,6 @@ class CryostatClientTest {
 
         client.submitCredentialsIfRequired(-1, credentials, callback).get();
 
-        Arrays.fill(password, (byte) 0);
-
         String entityContent = submittedCredentialRequestBody.get();
         assertNotNull(entityContent, "Should have captured credential submission request body");
         assertTrue(
@@ -304,10 +301,6 @@ class CryostatClientTest {
         assertFalse(
                 entityContent.contains("\u0000"),
                 "Multipart body should not contain null bytes from later password mutation");
-        assertArrayEquals(
-                new byte[password.length],
-                password,
-                "Source password array should be zeroed after explicit mutation");
     }
 
     private CryostatClient.StoredCredential createStoredCredential(int id) {

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -103,9 +103,7 @@ class CryostatClientTest {
                         invocation -> {
                             HttpPost request = invocation.getArgument(1);
                             if (request.getUri().getPath().contains("/api/v4/credentials")
-                                    && !request.getUri()
-                                            .getPath()
-                                            .contains("credential_exists")) {
+                                    && !request.getUri().getPath().contains("credential_exists")) {
                                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                                 request.getEntity().writeTo(out);
                                 submittedCredentialRequestBody.set(
@@ -151,9 +149,7 @@ class CryostatClientTest {
         assertTrue(
                 entityContent.contains("target.annotations.cryostat[\"REALM\"]"),
                 "Match expression should contain REALM clause");
-        assertTrue(
-                entityContent.contains(REALM),
-                "Match expression should contain realm value");
+        assertTrue(entityContent.contains(REALM), "Match expression should contain realm value");
     }
 
     @Test
@@ -182,9 +178,7 @@ class CryostatClientTest {
                         invocation -> {
                             HttpPost request = invocation.getArgument(1);
                             if (request.getUri().getPath().contains("/api/v4/credentials")
-                                    && !request.getUri()
-                                            .getPath()
-                                            .contains("credential_exists")) {
+                                    && !request.getUri().getPath().contains("credential_exists")) {
                                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                                 request.getEntity().writeTo(out);
                                 submittedCredentialRequestBody.set(
@@ -272,9 +266,7 @@ class CryostatClientTest {
                         invocation -> {
                             HttpPost request = invocation.getArgument(1);
                             if (request.getUri().getPath().contains("/api/v4/credentials")
-                                    && !request.getUri()
-                                            .getPath()
-                                            .contains("credential_exists")) {
+                                    && !request.getUri().getPath().contains("credential_exists")) {
                                 ByteArrayOutputStream out = new ByteArrayOutputStream();
                                 request.getEntity().writeTo(out);
                                 submittedCredentialRequestBody.set(

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -20,12 +20,14 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.InputStream;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.cryostat.agent.CryostatClient.DiscoveryPublication;
 import io.cryostat.agent.WebServer.Credentials;
@@ -94,9 +96,24 @@ class CryostatClientTest {
     @Test
     void testSubmitCredentialsIncludesRealmInMatchExpression() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
+        AtomicReference<String> submittedCredentialRequestBody = new AtomicReference<>();
 
         when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenReturn(checkResponse, submitResponse);
+                .thenAnswer(
+                        invocation -> {
+                            HttpPost request = invocation.getArgument(1);
+                            if (request.getUri().getPath().contains("/api/v4/credentials")
+                                    && !request.getUri()
+                                            .getPath()
+                                            .contains("credential_exists")) {
+                                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                                request.getEntity().writeTo(out);
+                                submittedCredentialRequestBody.set(
+                                        out.toString(StandardCharsets.UTF_8));
+                                return submitResponse;
+                            }
+                            return checkResponse;
+                        });
         lenient().when(checkResponse.getCode()).thenReturn(404);
         lenient().when(checkResponse.getEntity()).thenReturn(checkEntity);
         lenient()
@@ -117,42 +134,26 @@ class CryostatClientTest {
 
         client.submitCredentialsIfRequired(-1, credentials, callback).get();
 
-        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
-        verify(http, atLeastOnce()).execute(any(HttpHost.class), requestCaptor.capture());
-
-        boolean foundCredentialSubmission = false;
-        for (HttpPost capturedRequest : requestCaptor.getAllValues()) {
-            if (capturedRequest.getUri().getPath().contains("/api/v4/credentials")
-                    && !capturedRequest.getUri().getPath().contains("credential_exists")) {
-                HttpEntity requestEntity = capturedRequest.getEntity();
-                assertNotNull(requestEntity, "Request entity should not be null");
-
-                String entityContent = new String(requestEntity.getContent().readAllBytes());
-
-                assertTrue(
-                        entityContent.contains("target.connectUrl"),
-                        "Match expression should contain connectUrl clause");
-                assertTrue(
-                        entityContent.contains(callback.toString()),
-                        "Match expression should contain callback URL");
-                assertTrue(
-                        entityContent.contains("target.annotations.platform[\"INSTANCE_ID\"]"),
-                        "Match expression should contain INSTANCE_ID clause");
-                assertTrue(
-                        entityContent.contains(INSTANCE_ID),
-                        "Match expression should contain instance ID value");
-                assertTrue(
-                        entityContent.contains("target.annotations.cryostat[\"REALM\"]"),
-                        "Match expression should contain REALM clause");
-                assertTrue(
-                        entityContent.contains(REALM),
-                        "Match expression should contain realm value");
-                foundCredentialSubmission = true;
-                break;
-            }
-        }
-
-        assertTrue(foundCredentialSubmission, "Should have found credential submission request");
+        String entityContent = submittedCredentialRequestBody.get();
+        assertNotNull(entityContent, "Should have captured credential submission request body");
+        assertTrue(
+                entityContent.contains("target.connectUrl"),
+                "Match expression should contain connectUrl clause");
+        assertTrue(
+                entityContent.contains(callback.toString()),
+                "Match expression should contain callback URL");
+        assertTrue(
+                entityContent.contains("target.annotations.platform[\"INSTANCE_ID\"]"),
+                "Match expression should contain INSTANCE_ID clause");
+        assertTrue(
+                entityContent.contains(INSTANCE_ID),
+                "Match expression should contain instance ID value");
+        assertTrue(
+                entityContent.contains("target.annotations.cryostat[\"REALM\"]"),
+                "Match expression should contain REALM clause");
+        assertTrue(
+                entityContent.contains(REALM),
+                "Match expression should contain realm value");
     }
 
     @Test
@@ -174,9 +175,24 @@ class CryostatClientTest {
                         discoveryPublication);
 
         URI callback = URI.create("http://agent.example.com:9977");
+        AtomicReference<String> submittedCredentialRequestBody = new AtomicReference<>();
 
         when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenReturn(checkResponse, submitResponse);
+                .thenAnswer(
+                        invocation -> {
+                            HttpPost request = invocation.getArgument(1);
+                            if (request.getUri().getPath().contains("/api/v4/credentials")
+                                    && !request.getUri()
+                                            .getPath()
+                                            .contains("credential_exists")) {
+                                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                                request.getEntity().writeTo(out);
+                                submittedCredentialRequestBody.set(
+                                        out.toString(StandardCharsets.UTF_8));
+                                return submitResponse;
+                            }
+                            return checkResponse;
+                        });
         lenient().when(checkResponse.getCode()).thenReturn(404);
         lenient().when(checkResponse.getEntity()).thenReturn(checkEntity);
         lenient()
@@ -197,28 +213,14 @@ class CryostatClientTest {
 
         clientWithDifferentRealm.submitCredentialsIfRequired(-1, credentials, callback).get();
 
-        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
-        verify(http, atLeastOnce()).execute(any(HttpHost.class), requestCaptor.capture());
-
-        boolean foundCredentialSubmission = false;
-        for (HttpPost capturedRequest : requestCaptor.getAllValues()) {
-            if (capturedRequest.getUri().getPath().contains("/api/v4/credentials")
-                    && !capturedRequest.getUri().getPath().contains("credential_exists")) {
-                HttpEntity requestEntity = capturedRequest.getEntity();
-                String entityContent = new String(requestEntity.getContent().readAllBytes());
-
-                assertTrue(
-                        entityContent.contains(differentRealm),
-                        "Match expression should contain the different realm value");
-                assertFalse(
-                        entityContent.contains(REALM),
-                        "Match expression should not contain the original realm value");
-                foundCredentialSubmission = true;
-                break;
-            }
-        }
-
-        assertTrue(foundCredentialSubmission, "Should have found credential submission request");
+        String entityContent = submittedCredentialRequestBody.get();
+        assertNotNull(entityContent, "Should have captured credential submission request body");
+        assertTrue(
+                entityContent.contains(differentRealm),
+                "Match expression should contain the different realm value");
+        assertFalse(
+                entityContent.contains(REALM),
+                "Match expression should not contain the original realm value");
     }
 
     @Test
@@ -263,9 +265,24 @@ class CryostatClientTest {
     void testSubmitCredentialsUsesDefensivePasswordCopy() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
         byte[] password = "testpass".getBytes(StandardCharsets.UTF_8);
+        AtomicReference<String> submittedCredentialRequestBody = new AtomicReference<>();
 
         when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenReturn(checkResponse, submitResponse);
+                .thenAnswer(
+                        invocation -> {
+                            HttpPost request = invocation.getArgument(1);
+                            if (request.getUri().getPath().contains("/api/v4/credentials")
+                                    && !request.getUri()
+                                            .getPath()
+                                            .contains("credential_exists")) {
+                                ByteArrayOutputStream out = new ByteArrayOutputStream();
+                                request.getEntity().writeTo(out);
+                                submittedCredentialRequestBody.set(
+                                        out.toString(StandardCharsets.UTF_8));
+                                return submitResponse;
+                            }
+                            return checkResponse;
+                        });
         lenient().when(checkResponse.getCode()).thenReturn(404);
         lenient().when(checkResponse.getEntity()).thenReturn(checkEntity);
         lenient()
@@ -287,33 +304,18 @@ class CryostatClientTest {
 
         Arrays.fill(password, (byte) 0);
 
-        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
-        verify(http, atLeastOnce()).execute(any(HttpHost.class), requestCaptor.capture());
-
-        boolean foundCredentialSubmission = false;
-        for (HttpPost capturedRequest : requestCaptor.getAllValues()) {
-            if (capturedRequest.getUri().getPath().contains("/api/v4/credentials")
-                    && !capturedRequest.getUri().getPath().contains("credential_exists")) {
-                HttpEntity requestEntity = capturedRequest.getEntity();
-                assertNotNull(requestEntity, "Request entity should not be null");
-
-                String entityContent =
-                        new String(
-                                requestEntity.getContent().readAllBytes(), StandardCharsets.UTF_8);
-
-                assertTrue(
-                        entityContent.contains("testpass"),
-                        "Multipart body should retain the original password contents");
-                assertFalse(
-                        entityContent.contains("\u0000"),
-                        "Multipart body should not contain null bytes from later password"
-                                + " mutation");
-                foundCredentialSubmission = true;
-                break;
-            }
-        }
-
-        assertTrue(foundCredentialSubmission, "Should have found credential submission request");
+        String entityContent = submittedCredentialRequestBody.get();
+        assertNotNull(entityContent, "Should have captured credential submission request body");
+        assertTrue(
+                entityContent.contains("testpass"),
+                "Multipart body should retain the original password contents");
+        assertFalse(
+                entityContent.contains("\u0000"),
+                "Multipart body should not contain null bytes from later password mutation");
+        assertArrayEquals(
+                new byte[password.length],
+                password,
+                "Source password array should be zeroed after explicit mutation");
     }
 
     private CryostatClient.StoredCredential createStoredCredential(int id) {

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -22,6 +22,8 @@ import static org.mockito.Mockito.*;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
@@ -255,6 +257,63 @@ class CryostatClientTest {
         }
 
         assertTrue(foundCredentialCheck, "Should have found credential check request");
+    }
+
+    @Test
+    void testSubmitCredentialsUsesDefensivePasswordCopy() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        byte[] password = "testpass".getBytes(StandardCharsets.UTF_8);
+
+        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
+                .thenReturn(checkResponse, submitResponse);
+        lenient().when(checkResponse.getCode()).thenReturn(404);
+        lenient().when(checkResponse.getEntity()).thenReturn(checkEntity);
+        lenient()
+                .when(checkEntity.getContent())
+                .thenReturn(new ByteArrayInputStream("{}".getBytes()));
+        lenient().when(submitResponse.getCode()).thenReturn(201);
+        lenient().when(submitResponse.getEntity()).thenReturn(submitEntity);
+        lenient()
+                .when(submitResponse.getFirstHeader("Location"))
+                .thenReturn(new BasicHeader("Location", "/api/v4/credentials/42"));
+        lenient()
+                .when(submitEntity.getContent())
+                .thenReturn(new ByteArrayInputStream("".getBytes()));
+
+        when(credentials.user()).thenReturn("testuser");
+        when(credentials.pass()).thenReturn(password);
+
+        client.submitCredentialsIfRequired(-1, credentials, callback).get();
+
+        Arrays.fill(password, (byte) 0);
+
+        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+        verify(http, atLeastOnce()).execute(any(HttpHost.class), requestCaptor.capture());
+
+        boolean foundCredentialSubmission = false;
+        for (HttpPost capturedRequest : requestCaptor.getAllValues()) {
+            if (capturedRequest.getUri().getPath().contains("/api/v4/credentials")
+                    && !capturedRequest.getUri().getPath().contains("credential_exists")) {
+                HttpEntity requestEntity = capturedRequest.getEntity();
+                assertNotNull(requestEntity, "Request entity should not be null");
+
+                String entityContent =
+                        new String(
+                                requestEntity.getContent().readAllBytes(), StandardCharsets.UTF_8);
+
+                assertTrue(
+                        entityContent.contains("testpass"),
+                        "Multipart body should retain the original password contents");
+                assertFalse(
+                        entityContent.contains("\u0000"),
+                        "Multipart body should not contain null bytes from later password"
+                                + " mutation");
+                foundCredentialSubmission = true;
+                break;
+            }
+        }
+
+        assertTrue(foundCredentialSubmission, "Should have found credential submission request");
     }
 
     private CryostatClient.StoredCredential createStoredCredential(int id) {

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -19,6 +19,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.net.URI;
 import java.time.Duration;
 import java.util.List;
 import java.util.Random;
@@ -103,13 +104,13 @@ class RegistrationTest {
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(random.nextDouble()).thenReturn(0.5);
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
 
         ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
 
-        // Trigger three failures
         registration.tryRegister();
         registration.tryRegister();
         registration.tryRegister();
@@ -129,7 +130,6 @@ class RegistrationTest {
                                 + " got %d",
                         REGISTRATION_RETRY_MS, firstDelay));
 
-        // Second failure - should apply exponential backoff
         long secondDelay = delays.get(1);
         long expectedSecondDelay = (long) (REGISTRATION_RETRY_MS * BACKOFF_MULTIPLIER);
         assertTrue(
@@ -140,7 +140,6 @@ class RegistrationTest {
                                 + " ~%d, got %d",
                         expectedSecondDelay, secondDelay));
 
-        // Third failure - should continue exponential backoff
         long thirdDelay = delays.get(2);
         long expectedThirdDelay = (long) (REGISTRATION_RETRY_MS * Math.pow(BACKOFF_MULTIPLIER, 2));
         assertTrue(
@@ -157,13 +156,13 @@ class RegistrationTest {
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(random.nextDouble()).thenReturn(0.5);
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
 
         ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
 
-        // Simulate many failures to reach max backoff
         for (int i = 0; i < 15; i++) {
             registration.tryRegister();
         }
@@ -171,7 +170,6 @@ class RegistrationTest {
         verify(executor, times(15))
                 .schedule(any(Runnable.class), delayCaptor.capture(), eq(TimeUnit.MILLISECONDS));
 
-        // Check that later delays don't exceed max backoff
         long lastDelay = delayCaptor.getAllValues().get(14);
         assertTrue(
                 lastDelay <= MAX_BACKOFF_MS * 1.1,
@@ -184,24 +182,21 @@ class RegistrationTest {
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(random.nextDouble()).thenReturn(0.5);
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
 
-        // Trigger failures up to threshold
         for (int i = 0; i < CIRCUIT_BREAKER_THRESHOLD; i++) {
             registration.tryRegister();
         }
 
-        // Circuit should now be OPEN
-        // Next attempt should schedule with circuit breaker duration / 10
         registration.tryRegister();
 
         ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
         verify(executor, atLeast(CIRCUIT_BREAKER_THRESHOLD + 1))
                 .schedule(any(Runnable.class), delayCaptor.capture(), eq(TimeUnit.MILLISECONDS));
 
-        // The last scheduled delay should be the circuit breaker check interval
         long lastDelay = delayCaptor.getAllValues().get(CIRCUIT_BREAKER_THRESHOLD);
         long expectedCircuitCheckDelay = CIRCUIT_BREAKER_DURATION.toMillis() / 10;
         assertEquals(
@@ -212,21 +207,17 @@ class RegistrationTest {
 
     @Test
     void testSuccessfulRegistrationResetsFailureCount() throws Exception {
-        // Since mocking a full successful registration is complex, we verify the
-        // behavior is correct by checking that the exponential backoff pattern
-        // is working as expected through the delay values.
-
         when(webServer.getCredentialId()).thenReturn(1);
         when(random.nextDouble()).thenReturn(0.5);
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
 
         ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
 
-        // Trigger multiple failures to verify exponential backoff is working
         for (int i = 0; i < 5; i++) {
             registration.tryRegister();
         }
@@ -253,10 +244,10 @@ class RegistrationTest {
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
 
-        // Test with different random values to ensure jitter is applied
         when(random.nextDouble()).thenReturn(0.0, 0.5, 1.0);
 
         ArgumentCaptor<Long> delayCaptor = ArgumentCaptor.forClass(Long.class);
@@ -278,12 +269,11 @@ class RegistrationTest {
 
     @Test
     void testCircuitBreakerTransitionsToHalfOpen() throws Exception {
-        // This test would require time manipulation or a way to advance time
-        // For now, we verify the basic structure is in place
         when(webServer.getCredentialId()).thenReturn(1);
         when(cryostat.serverHealth())
                 .thenReturn(
                         CompletableFuture.failedFuture(new RuntimeException("Connection failed")));
+        when(cryostat.credentialExists(1)).thenReturn(CompletableFuture.completedFuture(false));
         when(random.nextDouble()).thenReturn(0.5);
         when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
                 .thenReturn(null);
@@ -447,5 +437,65 @@ class RegistrationTest {
                 scheduledDelay <= Duration.ofSeconds(30).toMillis(),
                 "Retry delay should be scheduled within the remaining minimum interval window");
         verify(cryostat, times(1)).serverHealth();
+    }
+
+    void testRegistrationFailureRetainsCredentialIdWhenCredentialStillExists() {
+        when(webServer.getCredentialId()).thenReturn(42);
+        when(cryostat.serverHealth())
+                .thenReturn(
+                        CompletableFuture.failedFuture(
+                                new RuntimeException("Server health failed")));
+        when(cryostat.credentialExists(42)).thenReturn(CompletableFuture.completedFuture(true));
+        when(random.nextDouble()).thenReturn(0.5);
+        when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+                .thenReturn(null);
+
+        registration.tryRegister();
+
+        verify(webServer, never()).resetCredentialId();
+        verify(cryostat).credentialExists(42);
+        verify(cryostat, never()).register(anyInt(), any(), any(URI.class));
+        verify(executor).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void testRegistrationFailureResetsCredentialIdWhenServerHealthFailsAndCredentialIsMissing() {
+        when(webServer.getCredentialId()).thenReturn(42);
+        when(cryostat.serverHealth())
+                .thenReturn(
+                        CompletableFuture.failedFuture(
+                                new RuntimeException("Server health failed")));
+        when(cryostat.credentialExists(42)).thenReturn(CompletableFuture.completedFuture(false));
+        when(random.nextDouble()).thenReturn(0.5);
+        when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+                .thenReturn(null);
+
+        registration.tryRegister();
+
+        verify(webServer).resetCredentialId();
+        verify(cryostat).credentialExists(42);
+        verify(cryostat, never()).register(anyInt(), any(), any(URI.class));
+        verify(executor).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void testRegistrationFailureRetainsCredentialIdWhenServerHealthFailsAndCredentialCheckFails() {
+        when(webServer.getCredentialId()).thenReturn(42);
+        when(cryostat.serverHealth())
+                .thenReturn(
+                        CompletableFuture.failedFuture(
+                                new RuntimeException("Server health failed")));
+        when(cryostat.credentialExists(42))
+                .thenReturn(CompletableFuture.failedFuture(new RuntimeException("Lookup failed")));
+        when(random.nextDouble()).thenReturn(0.5);
+        when(executor.schedule(any(Runnable.class), anyLong(), any(TimeUnit.class)))
+                .thenReturn(null);
+
+        registration.tryRegister();
+
+        verify(webServer, never()).resetCredentialId();
+        verify(cryostat).credentialExists(42);
+        verify(cryostat, never()).register(anyInt(), any(), any(URI.class));
+        verify(executor).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
     }
 }

--- a/src/test/java/io/cryostat/agent/WebServerTest.java
+++ b/src/test/java/io/cryostat/agent/WebServerTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.net.URI;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+
+import io.cryostat.agent.remote.RemoteContext;
+
+import com.sun.net.httpserver.HttpServer;
+import dagger.Lazy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WebServerTest {
+
+    @Mock Lazy<Set<RemoteContext>> remoteContexts;
+    @Mock Lazy<CryostatClient> cryostatClientLazy;
+    @Mock Lazy<Registration> registrationLazy;
+    @Mock HttpServer httpServer;
+    @Mock CryostatClient cryostatClient;
+    @Mock Registration registration;
+
+    private WebServer webServer;
+
+    @BeforeEach
+    void setup() throws Exception {
+        when(cryostatClientLazy.get()).thenReturn(cryostatClient);
+
+        webServer =
+                new WebServer(
+                        new SecureRandom(),
+                        remoteContexts,
+                        cryostatClientLazy,
+                        httpServer,
+                        MessageDigest.getInstance("SHA-256"),
+                        "testuser",
+                        16,
+                        registrationLazy);
+    }
+
+    @Test
+    void testGenerateCredentialsCoalescesConcurrentRequests() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        CompletableFuture<Integer> submission = new CompletableFuture<>();
+
+        when(cryostatClient.submitCredentialsIfRequired(anyInt(), any(), eq(callback)))
+                .thenReturn(submission);
+
+        CompletableFuture<Void> first = webServer.generateCredentials(callback);
+        CompletableFuture<Void> second = webServer.generateCredentials(callback);
+
+        assertSame(first, second, "Concurrent credential generation should share the same future");
+        verify(cryostatClient, times(1)).submitCredentialsIfRequired(anyInt(), any(), eq(callback));
+
+        submission.complete(42);
+
+        first.get();
+        second.get();
+
+        assertEquals(
+                42,
+                webServer.getCredentialId(),
+                "Credential ID should be updated from the shared result");
+    }
+
+    @Test
+    void testGenerateCredentialsAllowsNewAttemptAfterCompletion() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+
+        when(cryostatClient.submitCredentialsIfRequired(anyInt(), any(), eq(callback)))
+                .thenReturn(
+                        CompletableFuture.completedFuture(41),
+                        CompletableFuture.completedFuture(42));
+
+        CompletableFuture<Void> first = webServer.generateCredentials(callback);
+        first.get();
+
+        CompletableFuture<Void> second = webServer.generateCredentials(callback);
+        second.get();
+
+        assertNotSame(
+                first, second, "A completed generation should not block a later fresh attempt");
+        verify(cryostatClient, times(2)).submitCredentialsIfRequired(anyInt(), any(), eq(callback));
+        assertEquals(
+                42,
+                webServer.getCredentialId(),
+                "Latest completed generation should update credential ID");
+    }
+}


### PR DESCRIPTION
Based on #860
Depends on #860

1. Agent checks with Cryostat's credential keyring if the ID of the credential the Agent previously submitted (if any) is still present. If so, the Agent assumes this credential is still valid and does not submit a new one.
2. If the Agent is triggered to enter its registration flow rapidly and a credential generation request is already in-flight, then subsequent requests will reuse a coalesced response from the original in-flight request rather than possibly firing a second request while the first is still in-flight. This also prevents the Agent from rapidly regenerating and invalidating its own webserver credentials.
3. Fixes a byte buffer mutation mishandling where the temporary in-memory webserver password buffer might be zeroed out while the request submitting it to Cryostat's credential keyring is still underway.
