### PR TITLE
fix(credential): improve deletion error handling

### DIFF
--- a/src/main/java/io/cryostat/agent/CredentialCleanupJob.java
+++ b/src/main/java/io/cryostat/agent/CredentialCleanupJob.java
@@ -30,6 +30,7 @@ import javax.inject.Named;
 import javax.inject.Singleton;
 
 import dagger.Lazy;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,13 +116,11 @@ public class CredentialCleanupJob {
                             .handle(
                                     (v, t) -> {
                                         if (t != null) {
-                                            Throwable cause = t;
-                                            while (cause.getCause() != null) {
-                                                cause = cause.getCause();
-                                            }
-                                            if (cause instanceof HttpException
-                                                    && ((HttpException) cause).statusCode()
-                                                            == 404) {
+                                            HttpException httpException =
+                                                    ExceptionUtils.throwableOfType(
+                                                            t, HttpException.class);
+                                            if (httpException != null
+                                                    && httpException.statusCode() == 404) {
                                                 log.debug(
                                                         "Credential {} was already deleted"
                                                                 + " remotely",

--- a/src/main/java/io/cryostat/agent/CredentialTracker.java
+++ b/src/main/java/io/cryostat/agent/CredentialTracker.java
@@ -42,6 +42,7 @@ public class CredentialTracker {
 
     public void trackDeleted(int credentialId) {
         createdCredentials.remove(credentialId);
+        pendingDeletion.remove(credentialId);
         log.debug("Credential deleted: {}", credentialId);
     }
 

--- a/src/test/java/io/cryostat/agent/CredentialCleanupJobTest.java
+++ b/src/test/java/io/cryostat/agent/CredentialCleanupJobTest.java
@@ -140,4 +140,26 @@ class CredentialCleanupJobTest {
         verify(cryostatClient, times(MAX_RETRIES)).deleteCredentials(1);
         verify(tracker, times(1)).trackDeleted(1);
     }
+
+    @Test
+    void testCleanupOrphanedCredentialsHandles404AndDoesNotRetry() {
+        CredentialTracker tracker = new CredentialTracker();
+        tracker.trackCreated(1);
+        tracker.markForDeletion(1);
+
+        CredentialCleanupJob jobWithRealTracker =
+                new CredentialCleanupJob(
+                        executor, tracker, cryostat, CLEANUP_INTERVAL, MAX_RETRIES);
+
+        HttpException notFoundException = new HttpException(404, new RuntimeException("Not Found"));
+        when(cryostatClient.deleteCredentials(1))
+                .thenReturn(CompletableFuture.failedFuture(notFoundException));
+
+        // Run cleanup twice. Second time should not attempt deletion again
+        jobWithRealTracker.cleanupOrphanedCredentials();
+        jobWithRealTracker.cleanupOrphanedCredentials();
+
+        // Should only delete once
+        verify(cryostatClient, times(1)).deleteCredentials(1);
+    }
 }


### PR DESCRIPTION
See #861

Improve handling of HTTP 404 on credential deletion so that the Agent does not (should not) continue trying to delete credentials when the server tells the Agent these credentials already don't exist.
