### PR TITLE
chore(deps): update registry.access.redhat.com/ubi9-micro docker tag to v9.8-1779773398 (backport #883)

### DIFF
--- a/src/main/container/Dockerfile
+++ b/src/main/container/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9-micro:9.8-1777876409
+FROM registry.access.redhat.com/ubi9-micro:9.8-1779773398
 ARG OUTDIR=/cryostat/agent
 COPY target/cryostat-agent-*-shaded.jar ${OUTDIR}/
 RUN ln -s ${OUTDIR}/cryostat-agent-*-shaded.jar ${OUTDIR}/cryostat-agent-shaded.jar


### PR DESCRIPTION
Co-authored-by: renovate[bot] <29139614+renovate[bot]@users.noreply.github.com>