### PR TITLE
fix(http): remove CompressionFilter to ensure HttpConnection release

### DIFF
--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -57,7 +57,6 @@ class WebServer {
 
     private final AgentAuthenticator agentAuthenticator;
     private final RequestLoggingFilter requestLoggingFilter;
-    private final CompressionFilter compressionFilter;
     private final CooldownFilter cooldownFilter;
 
     private volatile ServerState serverState = ServerState.STOPPED;
@@ -86,7 +85,6 @@ class WebServer {
 
         this.agentAuthenticator = new AgentAuthenticator();
         this.requestLoggingFilter = new RequestLoggingFilter();
-        this.compressionFilter = new CompressionFilter();
         this.cooldownFilter = new CooldownFilter();
     }
 
@@ -105,7 +103,6 @@ class WebServer {
                             ctx.getFilters().add(0, cooldownFilter);
                             ctx.setAuthenticator(agentAuthenticator);
                             ctx.getFilters().add(requestLoggingFilter);
-                            ctx.getFilters().add(compressionFilter);
                         });
         this.http.start();
 
@@ -299,54 +296,6 @@ class WebServer {
         @Override
         public String description() {
             return "requestLog";
-        }
-    }
-
-    private class CompressionFilter extends Filter {
-
-        @Override
-        public void doFilter(HttpExchange exchange, Chain chain) throws IOException {
-            List<String> requestedEncodings =
-                    exchange.getRequestHeaders().getOrDefault("Accept-Encoding", List.of()).stream()
-                            .map(raw -> raw.replaceAll("\\s", ""))
-                            .map(raw -> raw.split(","))
-                            .map(Arrays::asList)
-                            .flatMap(List::stream)
-                            .collect(Collectors.toList());
-            String negotiatedEncoding = null;
-            priority:
-            for (String encoding : requestedEncodings) {
-                switch (encoding) {
-                    case "deflate":
-                        negotiatedEncoding = encoding;
-                        exchange.setStreams(
-                                exchange.getRequestBody(),
-                                new DeflaterOutputStream(exchange.getResponseBody()));
-                        break priority;
-                        // TODO gzip encoding breaks communication with the server, need to
-                        // determine why and re-enable this
-                        // case "gzip":
-                        // actualEncoding = requestedEncoding;
-                        // exchange.setStreams(
-                        //         exchange.getRequestBody(),
-                        //         new GZIPOutputStream(exchange.getResponseBody()));
-                        // break priority;
-                    default:
-                        break;
-                }
-            }
-            if (negotiatedEncoding == null) {
-                log.trace("Using no encoding");
-            } else {
-                log.trace("Using '{}' encoding", negotiatedEncoding);
-                exchange.getResponseHeaders().put("Content-Encoding", List.of(negotiatedEncoding));
-            }
-            chain.doFilter(exchange);
-        }
-
-        @Override
-        public String description() {
-            return "responseCompression";
         }
     }
 

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -23,13 +23,10 @@ import java.security.SecureRandom;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import java.util.zip.DeflaterOutputStream;
 
 import io.cryostat.agent.remote.RemoteContext;
 


### PR DESCRIPTION
Fixes #915

The JDK HttpServer has somewhat sensitive internal state tracking for connection states from active to idle, and for reaping idle connections. The CompressionFilter's replacement of the HttpExchange's body OutputStream seems to break the HttpServer's state tracking, resulting in the HttpConnection never being reaped. As described in #915 this leads to increased memory pressure and potential file descriptor exhaustion. I haven't tested the case where fds get exhausted, but in #917 I did experiment with setting system properties to define maximum connection and idleConnection limits for the JDK HttpServer, and I found that when the maximum connection count is reached due to stale connections failing to be reaped, the HttpServer becomes unable to receive any further incoming requests and therefore Cryostat's plugin ping attempts fail, eventually resulting in target discovery degradation.

#587 or something similar might be a good approach to restore compression support eventually, but the Agent HttpServer is not typically returning back particularly large response bodies to Cryostat, so a lack of compression support is not critical. I also don't believe Cryostat's HTTP client for communicating with Agent instances even requests compression anymore (since 3.0, probably), so I think this has been effectively dead code for a long time. I tried to get the CompressionFilter working such that the HttpServer would release HttpConnections but have not found a good solution, so simply removing the CompressionFilter seems like the most prudent choice currently.