### PR TITLE
feat(harvester): include labels for startTime, duration, and sourceRecordingId (remoteId)

### DIFF
--- a/src/main/java/io/cryostat/agent/harvest/Harvester.java
+++ b/src/main/java/io/cryostat/agent/harvest/Harvester.java
@@ -375,7 +375,8 @@ public class Harvester implements FlightRecorderListener {
                         new IllegalStateException("No source recording data"));
             }
             log.trace("Dumping {}({}) to {}", recording.getName(), recording.getId(), exitPath);
-            return client.upload(pushType, sownRecording, maxFiles, additionalLabels(), exitPath)
+            return client.upload(
+                            pushType, sownRecording, maxFiles, additionalLabels(recording), exitPath)
                     .thenRun(
                             () -> {
                                 try {
@@ -395,14 +396,34 @@ public class Harvester implements FlightRecorderListener {
     private Future<Void> uploadRecording(TemplatedRecording tr) throws IOException {
         Path exitPath = exitPaths.get(tr);
         return client.upload(
-                PushType.ON_STOP, Optional.of(tr), maxFiles, additionalLabels(), exitPath);
+                PushType.ON_STOP,
+                Optional.of(tr),
+                maxFiles,
+                additionalLabels(tr.getRecording()),
+                exitPath);
     }
 
-    private Map<String, String> additionalLabels() {
+    Map<String, String> additionalLabels(Recording recording) {
         var map = new HashMap<String, String>();
         if (autoanalyze) {
             map.put(AUTOANALYZE_LABEL, String.valueOf(true));
         }
+        long startTime =
+                recording.getStartTime() != null
+                        ? recording.getStartTime().toEpochMilli()
+                        : 0L;
+        Duration dur = recording.getDuration();
+        long duration;
+        if (dur != null && dur.toMillis() != 0) {
+            duration = dur.toMillis();
+        } else if (recording.getMaxAge() != null) {
+            duration = recording.getMaxAge().toMillis();
+        } else {
+            duration = 0L;
+        }
+        map.put("startTime", String.valueOf(startTime));
+        map.put("duration", String.valueOf(duration));
+        map.put("sourceRecordingId", String.valueOf(recording.getId()));
         return map;
     }
 

--- a/src/main/java/io/cryostat/agent/harvest/Harvester.java
+++ b/src/main/java/io/cryostat/agent/harvest/Harvester.java
@@ -376,7 +376,11 @@ public class Harvester implements FlightRecorderListener {
             }
             log.trace("Dumping {}({}) to {}", recording.getName(), recording.getId(), exitPath);
             return client.upload(
-                            pushType, sownRecording, maxFiles, additionalLabels(recording), exitPath)
+                            pushType,
+                            sownRecording,
+                            maxFiles,
+                            additionalLabels(recording),
+                            exitPath)
                     .thenRun(
                             () -> {
                                 try {
@@ -409,9 +413,7 @@ public class Harvester implements FlightRecorderListener {
             map.put(AUTOANALYZE_LABEL, String.valueOf(true));
         }
         long startTime =
-                recording.getStartTime() != null
-                        ? recording.getStartTime().toEpochMilli()
-                        : 0L;
+                recording.getStartTime() != null ? recording.getStartTime().toEpochMilli() : 0L;
         Duration dur = recording.getDuration();
         long duration;
         if (dur != null && dur.toMillis() != 0) {

--- a/src/test/java/io/cryostat/agent/harvest/HarvesterTest.java
+++ b/src/test/java/io/cryostat/agent/harvest/HarvesterTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright The Cryostat Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cryostat.agent.harvest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.time.Duration;
+import java.util.Map;
+import java.util.concurrent.ScheduledExecutorService;
+
+import io.cryostat.agent.CryostatClient;
+import io.cryostat.agent.FlightRecorderHelper;
+import io.cryostat.agent.Registration;
+
+import jdk.jfr.Recording;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class HarvesterTest {
+
+    @Mock ScheduledExecutorService executor;
+    @Mock ScheduledExecutorService workerPool;
+    @Mock CryostatClient client;
+    @Mock FlightRecorderHelper flightRecorderHelper;
+    @Mock Registration registration;
+
+    private Harvester harvester;
+    private Recording recording;
+
+    @BeforeEach
+    void setup() {
+        Harvester.RecordingSettings exitSettings = new Harvester.RecordingSettings();
+        Harvester.RecordingSettings periodicSettings = new Harvester.RecordingSettings();
+        harvester =
+                new Harvester(
+                        executor,
+                        workerPool,
+                        -1L,
+                        "default",
+                        5,
+                        exitSettings,
+                        periodicSettings,
+                        false,
+                        client,
+                        flightRecorderHelper,
+                        registration);
+    }
+
+    @AfterEach
+    void cleanup() {
+        if (recording != null) {
+            recording.close();
+            recording = null;
+        }
+    }
+
+    @Test
+    void testAdditionalLabelsWithStartedRecording() {
+        recording = new Recording();
+        recording.setMaxAge(Duration.ofSeconds(30));
+        recording.start();
+
+        Map<String, String> labels = harvester.additionalLabels(recording);
+
+        long startTime = recording.getStartTime().toEpochMilli();
+        assertEquals(String.valueOf(startTime), labels.get("startTime"));
+        assertEquals(String.valueOf(30_000L), labels.get("duration"));
+        assertEquals(String.valueOf(recording.getId()), labels.get("sourceRecordingId"));
+    }
+
+    @Test
+    void testAdditionalLabelsWithFixedDurationRecording() {
+        recording = new Recording();
+        recording.setDuration(Duration.ofSeconds(10));
+        recording.start();
+
+        Map<String, String> labels = harvester.additionalLabels(recording);
+
+        assertEquals(String.valueOf(10_000L), labels.get("duration"));
+        assertEquals(String.valueOf(recording.getId()), labels.get("sourceRecordingId"));
+    }
+
+    @Test
+    void testAdditionalLabelsNullDurationAndNullMaxAge() {
+        recording = new Recording();
+
+        Map<String, String> labels = harvester.additionalLabels(recording);
+
+        assertEquals("0", labels.get("startTime"));
+        assertEquals("0", labels.get("duration"));
+        assertEquals(String.valueOf(recording.getId()), labels.get("sourceRecordingId"));
+    }
+
+    @Test
+    void testAdditionalLabelsWithAutoanalyzeEnabled() {
+        Harvester.RecordingSettings exitSettings = new Harvester.RecordingSettings();
+        Harvester.RecordingSettings periodicSettings = new Harvester.RecordingSettings();
+        Harvester autoanalyzeHarvester =
+                new Harvester(
+                        executor,
+                        workerPool,
+                        -1L,
+                        "default",
+                        5,
+                        exitSettings,
+                        periodicSettings,
+                        true,
+                        client,
+                        flightRecorderHelper,
+                        registration);
+
+        recording = new Recording();
+
+        Map<String, String> labels = autoanalyzeHarvester.additionalLabels(recording);
+
+        assertEquals("true", labels.get("autoanalyze"));
+        assertEquals("0", labels.get("startTime"));
+        assertEquals("0", labels.get("duration"));
+        assertEquals(String.valueOf(recording.getId()), labels.get("sourceRecordingId"));
+    }
+}


### PR DESCRIPTION
See cryostatio/cryostat#1669
Related to https://github.com/cryostatio/cryostat/issues/1665

Agent-side equivalent change - the Agent includes `startTime` and `duration` labels according to the same logic. The Agent does not know the database record ID corresponding to the recording it's pushing, but it does know the internal JFR recording ID - and Cryostat also knows that as the ActiveRecording `remoteId`. So, the Agent includes this ID as the `sourceRecordingId` label, and the Cryostat server knows to look for this label and to attempt to correlate that to the `remoteId` so that it can set the `activeRecordingId` label.
