### PR TITLE
ci(publish): skip spotless

### DIFF
--- a/.github/workflows/maven-central-publish.yml
+++ b/.github/workflows/maven-central-publish.yml
@@ -24,7 +24,7 @@ jobs:
           distribution: 'temurin'
           cache: maven
       - name: Run a build of the code base before release
-        run: ./mvnw --batch-mode --no-transfer-progress -Psnapshots clean install
+        run: ./mvnw --batch-mode --no-transfer-progress -Psnapshots -Dspotless.skip clean install
       # - name: Set release version
       #   run: ./mvnw --batch-mode --no-transfer-progress versions:set -DnewVersion=${{ github.event.inputs.version }}
       - name: Release with JReleaser

--- a/.github/workflows/pr-ci.yaml
+++ b/.github/workflows/pr-ci.yaml
@@ -57,7 +57,7 @@ jobs:
     - uses: skjolber/maven-cache-github-action@c4a30022e05fa8a86dde82cd8c1e49420d4a45dd # v3.1.2
       with:
         step: restore
-    - run: mvn clean compile spotbugs:check
+    - run: mvn -Psnapshots clean compile spotbugs:check
     - uses: skjolber/maven-cache-github-action@c4a30022e05fa8a86dde82cd8c1e49420d4a45dd # v3.1.2
       with:
         step: save


### PR DESCRIPTION
See #905

Spotless is already run and enforced on PRs, so it does not need to run again later after merge to main on publish (snapshots or release). This step is currently causing issues because the PRs are using JDK 25 and a compatible googleJavaFormat, but the actual build and publication steps use JDK 11 so that the published JAR is compatible back to JDK 11. The googleJavaFormat version is too new to run on JDK 11, causing the CI failure.
