### PR TITLE
fix(registration): keep stored credentials valid during refresh

### DIFF
--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -252,18 +252,18 @@ public class Registration {
         }
     }
 
-    void tryRegister() {
+    synchronized void tryRegister() {
+        if (currentRegistration != null && !currentRegistration.isDone()) {
+            log.debug("Registration attempt already in progress");
+            return;
+        }
+
         Instant shouldAttemptRegistrationAt = shouldAttemptRegistrationAt();
         if (Instant.now().isBefore(shouldAttemptRegistrationAt)) {
             long delay = Duration.between(Instant.now(), shouldAttemptRegistrationAt).toMillis();
             executor.schedule(
                     () -> notify(RegistrationEvent.State.REFRESHING), delay, TimeUnit.MILLISECONDS);
             return;
-        }
-
-        if (currentRegistration != null && !currentRegistration.isDone()) {
-            log.warn("Cancelling previous registration attempt");
-            currentRegistration.cancel(true);
         }
 
         if (isInCooldown()) {

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -333,6 +333,7 @@ public class Registration {
                                         return completeRegistrationFailure(t);
                                     }
 
+                                    webServer.commitPendingCredentials();
                                     boolean previouslyRegistered = this.pluginInfo.isInitialized();
                                     this.pluginInfo.copyFrom(plugin);
                                     log.debug("Registered as {}", this.pluginInfo.getId());
@@ -363,6 +364,7 @@ public class Registration {
     }
 
     private CompletableFuture<Void> completeRegistrationFailure(Throwable t) {
+        webServer.discardPendingCredentials();
         this.pluginInfo.clear();
 
         int failures = consecutiveFailures.incrementAndGet();

--- a/src/main/java/io/cryostat/agent/WebServer.java
+++ b/src/main/java/io/cryostat/agent/WebServer.java
@@ -211,6 +211,14 @@ class WebServer {
         return this.credentials.snapshot();
     }
 
+    void commitPendingCredentials() {
+        this.credentials.commitPending();
+    }
+
+    void discardPendingCredentials() {
+        this.credentials.discardPending();
+    }
+
     void clearPlaintextCredentials() {
         this.credentials.clear();
         synchronized (credentialGenerationLock) {
@@ -339,7 +347,11 @@ class WebServer {
         private final MessageDigest digest;
         private final String user;
         private final byte[] pass;
-        private byte[] passHash = new byte[0];
+        // Keep the credential known to Cryostat valid while its replacement registration is in
+        // flight. The replacement is accepted locally before the request starts, then becomes the
+        // sole active credential only after Cryostat acknowledges the registration.
+        private byte[] activePassHash = new byte[0];
+        private byte[] pendingPassHash = new byte[0];
 
         Credentials(SecureRandom random, MessageDigest digest, String user, int passLength) {
             this.random = random;
@@ -349,16 +361,20 @@ class WebServer {
         }
 
         synchronized boolean checkUserInfo(String username, String password) {
-            return passHash.length > 0
-                    && Objects.equals(username, user)
-                    && Arrays.equals(hash(password), this.passHash);
+            if (!Objects.equals(username, user)) {
+                return false;
+            }
+            byte[] hash = hash(password);
+            return Arrays.equals(hash, this.activePassHash)
+                    || Arrays.equals(hash, this.pendingPassHash);
         }
 
         synchronized void regenerate() {
             for (int idx = 0; idx < this.pass.length; idx++) {
                 this.pass[idx] = randomAscii();
             }
-            this.passHash = hash(this.pass);
+            Arrays.fill(this.pendingPassHash, (byte) 0);
+            this.pendingPassHash = hash(this.pass);
         }
 
         String user() {
@@ -367,6 +383,21 @@ class WebServer {
 
         synchronized void clear() {
             Arrays.fill(this.pass, (byte) 0);
+        }
+
+        synchronized void commitPending() {
+            if (this.pendingPassHash.length == 0) {
+                throw new IllegalStateException("credentials have not been generated");
+            }
+            Arrays.fill(this.activePassHash, (byte) 0);
+            this.activePassHash = this.pendingPassHash;
+            this.pendingPassHash = new byte[0];
+        }
+
+        synchronized void discardPending() {
+            clear();
+            Arrays.fill(this.pendingPassHash, (byte) 0);
+            this.pendingPassHash = new byte[0];
         }
 
         // generated passwords contain only printable ASCII, so an all-zero buffer can only
@@ -398,7 +429,7 @@ class WebServer {
         }
 
         synchronized CredentialsSnapshot snapshot() {
-            if (passHash.length == 0) {
+            if (pendingPassHash.length == 0) {
                 throw new IllegalStateException("credentials have not been generated");
             }
             if (isPlaintextCleared()) {

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -439,6 +439,18 @@ class RegistrationTest {
     }
 
     @Test
+    void testOverlappingRegistrationAttemptsAreSerialized() {
+        CompletableFuture<ServerHealth> health = new CompletableFuture<>();
+        when(cryostat.serverHealth()).thenReturn(health);
+
+        registration.tryRegister();
+        registration.tryRegister();
+
+        verify(webServer, times(1)).generateCredentials(nullable(URI.class));
+        verify(cryostat, times(1)).serverHealth();
+    }
+
+    @Test
     void testRegistrationFailureDoesNotCheckRemoteCredentialState() {
         when(cryostat.serverHealth())
                 .thenReturn(

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -28,6 +28,8 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.cryostat.agent.model.PluginInfo;
+import io.cryostat.agent.model.ServerHealth;
 import io.cryostat.agent.util.AppNameResolver;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -465,8 +467,40 @@ class RegistrationTest {
         registration.tryRegister();
 
         verify(webServer).clearPlaintextCredentials();
+        verify(webServer).discardPendingCredentials();
         verify(cryostat, never()).register(any(URI.class), any(), anyCollection());
         verify(executor).schedule(any(Runnable.class), anyLong(), eq(TimeUnit.MILLISECONDS));
+    }
+
+    @Test
+    void testSuccessfulRegistrationCommitsPendingCredentials() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        when(callbackResolver.determineSelfCallback()).thenReturn(callback);
+        when(appNameResolver.extractFromJavaCommand()).thenReturn("test.Main");
+        when(cryostat.serverHealth())
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new ServerHealth(
+                                        "4.3.0",
+                                        new ServerHealth.BuildInfo(
+                                                new ServerHealth.GitInfo("test-hash")))));
+        when(cryostat.register(eq(callback), any(), anyCollection()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "plugin-token", List.of())));
+        doAnswer(
+                        invocation -> {
+                            invocation.getArgument(0, Runnable.class).run();
+                            return scheduledFuture;
+                        })
+                .when(executor)
+                .submit(any(Runnable.class));
+
+        registration.start();
+
+        verify(webServer).commitPendingCredentials();
+        verify(webServer, never()).discardPendingCredentials();
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
     }
 
     @Test

--- a/src/test/java/io/cryostat/agent/WebServerTest.java
+++ b/src/test/java/io/cryostat/agent/WebServerTest.java
@@ -19,10 +19,17 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.SecureRandom;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Set;
 
 import io.cryostat.agent.remote.RemoteContext;
@@ -93,5 +100,114 @@ class WebServerTest {
 
         snapshot.close();
         assertArrayEquals(new byte[16], snapshot.pass());
+    }
+
+    @Test
+    void testStoredCredentialsRemainValidWhileReplacementRegistrationIsPending() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        HttpServer httpServer =
+                HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        SecureRandom random = mock(SecureRandom.class);
+        when(random.nextInt(anyInt())).thenReturn(0, 1);
+        WebServer liveWebServer =
+                new WebServer(
+                        random,
+                        Set::of,
+                        httpServer,
+                        MessageDigest.getInstance("SHA-256"),
+                        "testuser",
+                        16,
+                        () -> registration);
+
+        try {
+            liveWebServer.generateCredentials(callback).get();
+            try (WebServer.CredentialsSnapshot storedCredentials =
+                    liveWebServer.getCredentialsSnapshot()) {
+                liveWebServer.clearPlaintextCredentials();
+                liveWebServer.commitPendingCredentials();
+                liveWebServer.start();
+
+                HttpClient client = HttpClient.newHttpClient();
+                URI pingUri =
+                        new URI(
+                                "http",
+                                null,
+                                httpServer.getAddress().getHostString(),
+                                httpServer.getAddress().getPort(),
+                                "/",
+                                null,
+                                null);
+                String authorization =
+                        "Basic "
+                                + Base64.getEncoder()
+                                        .encodeToString(
+                                                (storedCredentials.user()
+                                                                + ":"
+                                                                + new String(
+                                                                        storedCredentials.pass(),
+                                                                        StandardCharsets.US_ASCII))
+                                                        .getBytes(StandardCharsets.US_ASCII));
+                HttpRequest ping =
+                        HttpRequest.newBuilder(pingUri)
+                                .header("Authorization", authorization)
+                                .GET()
+                                .build();
+
+                assertEquals(
+                        204,
+                        client.send(ping, HttpResponse.BodyHandlers.discarding()).statusCode());
+
+                liveWebServer.generateCredentials(callback).get();
+                try (WebServer.CredentialsSnapshot ignored =
+                        liveWebServer.getCredentialsSnapshot()) {
+                    assertEquals(
+                            204,
+                            client.send(ping, HttpResponse.BodyHandlers.discarding()).statusCode(),
+                            "Cryostat's stored credential must remain valid until its replacement"
+                                    + " is committed");
+                }
+            }
+        } finally {
+            liveWebServer.stop();
+        }
+    }
+
+    @Test
+    void testPendingCredentialsAreCommittedOrDiscardedAtomically() throws Exception {
+        SecureRandom random = mock(SecureRandom.class);
+        when(random.nextInt(anyInt())).thenReturn(0, 1);
+        WebServer.Credentials credentials =
+                new WebServer.Credentials(
+                        random, MessageDigest.getInstance("SHA-256"), "testuser", 16);
+
+        credentials.regenerate();
+        try (WebServer.CredentialsSnapshot stored = credentials.snapshot()) {
+            String storedPassword = new String(stored.pass(), StandardCharsets.US_ASCII);
+            credentials.commitPending();
+
+            credentials.regenerate();
+            try (WebServer.CredentialsSnapshot replacement = credentials.snapshot()) {
+                String replacementPassword =
+                        new String(replacement.pass(), StandardCharsets.US_ASCII);
+
+                assertTrue(credentials.checkUserInfo("testuser", storedPassword));
+                assertTrue(credentials.checkUserInfo("testuser", replacementPassword));
+
+                credentials.discardPending();
+
+                assertTrue(credentials.checkUserInfo("testuser", storedPassword));
+                assertFalse(credentials.checkUserInfo("testuser", replacementPassword));
+            }
+
+            credentials.regenerate();
+            try (WebServer.CredentialsSnapshot replacement = credentials.snapshot()) {
+                String replacementPassword =
+                        new String(replacement.pass(), StandardCharsets.US_ASCII);
+                credentials.commitPending();
+
+                assertFalse(credentials.checkUserInfo("testuser", storedPassword));
+                assertTrue(credentials.checkUserInfo("testuser", replacementPassword));
+            }
+        }
     }
 }


### PR DESCRIPTION
see https://github.com/cryostatio/cryostat-agent/issues/876

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved credential rotation during registration.
  * Existing credentials remain valid until registration completes successfully.
  * Pending credentials are automatically committed after successful registration.
  * Pending credentials are discarded when registration or server-health checks fail.
  * Authentication now handles credential replacement more reliably without interrupting service.
  * Overlapping registration attempts are now handled safely and consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->