### PR TITLE
fix(registration): refresh agent token without replacing credentials

### DIFF
--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -153,6 +153,62 @@ public class CryostatClient {
                 .whenComplete((v, t) -> req.reset());
     }
 
+    public CompletableFuture<PluginInfo> refreshRegistration(URI callback, PluginInfo pluginInfo) {
+        if (!pluginInfo.isInitialized()) {
+            return CompletableFuture.failedFuture(
+                    new IllegalStateException("registration has not been initialized"));
+        }
+        try {
+            RegistrationRefresh refresh =
+                    new RegistrationRefresh(
+                            pluginInfo.getId(), pluginInfo.getToken(), realm, callback);
+            HttpPost req = new HttpPost(baseUri.resolve(DISCOVERY_API_PATH));
+            log.trace("{}", req);
+            byte[] body = mapper.writeValueAsBytes(refresh);
+            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
+            return supply(req, res -> logResponse(req, res))
+                    .thenApply(res -> assertOkStatus(req, res))
+                    .thenApply(
+                            res -> {
+                                try (InputStream is = res.getEntity().getContent()) {
+                                    return mapper.readValue(is, PluginInfo.class);
+                                } catch (IOException e) {
+                                    log.error("Unable to parse response as JSON", e);
+                                    throw new RegistrationException(e);
+                                }
+                            })
+                    .whenComplete((v, t) -> req.reset())
+                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
+        } catch (JsonProcessingException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    public CompletableFuture<PluginInfo> activateRegistrationRefresh(URI callback) {
+        try {
+            RegistrationActivation activation = new RegistrationActivation(realm, callback);
+            HttpPost req = new HttpPost(baseUri.resolve(DISCOVERY_API_PATH));
+            log.trace("{}", req);
+            byte[] body = mapper.writeValueAsBytes(activation);
+            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
+            return supply(req, res -> logResponse(req, res))
+                    .thenApply(res -> assertOkStatus(req, res))
+                    .thenApply(
+                            res -> {
+                                try (InputStream is = res.getEntity().getContent()) {
+                                    return mapper.readValue(is, PluginInfo.class);
+                                } catch (IOException e) {
+                                    log.error("Unable to parse response as JSON", e);
+                                    throw new RegistrationException(e);
+                                }
+                            })
+                    .whenComplete((v, t) -> req.reset())
+                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
+        } catch (JsonProcessingException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
     public CompletableFuture<PluginInfo> register(
             URI callback, CredentialsSnapshot credentials, Collection<DiscoveryNode> subtree) {
         byte[] passwordCopy = credentials.pass();
@@ -495,6 +551,54 @@ public class CryostatClient {
 
         public Map<String, String> getContext() {
             return context;
+        }
+    }
+
+    static class RegistrationRefresh {
+        private final String id;
+        private final String token;
+        private final String realm;
+        private final URI callback;
+
+        RegistrationRefresh(String id, String token, String realm, URI callback) {
+            this.id = id;
+            this.token = token;
+            this.realm = realm;
+            this.callback = callback;
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public String getToken() {
+            return token;
+        }
+
+        public String getRealm() {
+            return realm;
+        }
+
+        public URI getCallback() {
+            return callback;
+        }
+    }
+
+    static class RegistrationActivation {
+        private final String realm;
+        private final URI callback;
+
+        RegistrationActivation(String realm, URI callback) {
+            this.realm = realm;
+            this.callback = callback;
+        }
+
+        public String getRealm() {
+            return realm;
+        }
+
+        public URI getCallback() {
+            return callback;
         }
     }
 

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -68,6 +68,7 @@ import org.apache.hc.client5.http.entity.mime.MultipartEntityBuilder;
 import org.apache.hc.client5.http.entity.mime.StringBody;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.ContentType;
+import org.apache.hc.core5.http.HttpEntity;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.entity.ByteArrayEntity;
 import org.apache.hc.core5.http.io.entity.StringEntity;
@@ -413,7 +414,15 @@ public class CryostatClient {
     }
 
     private PluginInfo parsePluginInfo(ClassicHttpResponse response) {
-        try (InputStream is = response.getEntity().getContent()) {
+        HttpEntity entity = response.getEntity();
+        if (entity == null) {
+            throw new RegistrationException(
+                    new IOException(
+                            String.format(
+                                    "Response (%d) contained no plugin information",
+                                    response.getCode())));
+        }
+        try (InputStream is = entity.getContent()) {
             return mapper.readValue(is, PluginInfo.class);
         } catch (IOException e) {
             log.error("Unable to parse response as JSON", e);

--- a/src/main/java/io/cryostat/agent/CryostatClient.java
+++ b/src/main/java/io/cryostat/agent/CryostatClient.java
@@ -158,55 +158,14 @@ public class CryostatClient {
             return CompletableFuture.failedFuture(
                     new IllegalStateException("registration has not been initialized"));
         }
-        try {
-            RegistrationRefresh refresh =
-                    new RegistrationRefresh(
-                            pluginInfo.getId(), pluginInfo.getToken(), realm, callback);
-            HttpPost req = new HttpPost(baseUri.resolve(DISCOVERY_API_PATH));
-            log.trace("{}", req);
-            byte[] body = mapper.writeValueAsBytes(refresh);
-            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
-            return supply(req, res -> logResponse(req, res))
-                    .thenApply(res -> assertOkStatus(req, res))
-                    .thenApply(
-                            res -> {
-                                try (InputStream is = res.getEntity().getContent()) {
-                                    return mapper.readValue(is, PluginInfo.class);
-                                } catch (IOException e) {
-                                    log.error("Unable to parse response as JSON", e);
-                                    throw new RegistrationException(e);
-                                }
-                            })
-                    .whenComplete((v, t) -> req.reset())
-                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
-        } catch (JsonProcessingException e) {
-            return CompletableFuture.failedFuture(e);
-        }
+        RegistrationRefresh refresh =
+                new RegistrationRefresh(pluginInfo.getId(), pluginInfo.getToken(), realm, callback);
+        return postForPluginInfo(baseUri.resolve(DISCOVERY_API_PATH), refresh);
     }
 
     public CompletableFuture<PluginInfo> activateRegistrationRefresh(URI callback) {
-        try {
-            RegistrationActivation activation = new RegistrationActivation(realm, callback);
-            HttpPost req = new HttpPost(baseUri.resolve(DISCOVERY_API_PATH));
-            log.trace("{}", req);
-            byte[] body = mapper.writeValueAsBytes(activation);
-            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
-            return supply(req, res -> logResponse(req, res))
-                    .thenApply(res -> assertOkStatus(req, res))
-                    .thenApply(
-                            res -> {
-                                try (InputStream is = res.getEntity().getContent()) {
-                                    return mapper.readValue(is, PluginInfo.class);
-                                } catch (IOException e) {
-                                    log.error("Unable to parse response as JSON", e);
-                                    throw new RegistrationException(e);
-                                }
-                            })
-                    .whenComplete((v, t) -> req.reset())
-                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
-        } catch (JsonProcessingException e) {
-            return CompletableFuture.failedFuture(e);
-        }
+        RegistrationActivation activation = new RegistrationActivation(realm, callback);
+        return postForPluginInfo(baseUri.resolve(DISCOVERY_API_PATH), activation);
     }
 
     public CompletableFuture<PluginInfo> register(
@@ -226,25 +185,7 @@ public class CryostatClient {
                             publication.getNodes(),
                             publication.getFillStrategy(),
                             publication.getContext());
-            HttpPost req = new HttpPost(baseUri.resolve(AGENT_REGISTRATION_API_PATH));
-            log.trace("{}", req);
-            byte[] body = mapper.writeValueAsBytes(registration);
-            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
-            return supply(req, (res) -> logResponse(req, res))
-                    .thenApply(res -> assertOkStatus(req, res))
-                    .thenApply(
-                            res -> {
-                                try (InputStream is = res.getEntity().getContent()) {
-                                    return mapper.readValue(is, PluginInfo.class);
-                                } catch (IOException e) {
-                                    log.error("Unable to parse response as JSON", e);
-                                    throw new RegistrationException(e);
-                                }
-                            })
-                    .whenComplete((v, t) -> req.reset())
-                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
-        } catch (JsonProcessingException e) {
-            return CompletableFuture.failedFuture(e);
+            return postForPluginInfo(baseUri.resolve(AGENT_REGISTRATION_API_PATH), registration);
         } finally {
             // the serialized request body holds its own copy of the password, so the
             // buffer can be cleared as soon as serialization has happened (or failed)
@@ -453,6 +394,31 @@ public class CryostatClient {
                             }
                             req.reset();
                         });
+    }
+
+    private CompletableFuture<PluginInfo> postForPluginInfo(URI uri, Object payload) {
+        try {
+            HttpPost req = new HttpPost(uri);
+            log.trace("{}", req);
+            byte[] body = mapper.writeValueAsBytes(payload);
+            req.setEntity(new ByteArrayEntity(body, ContentType.APPLICATION_JSON));
+            return supply(req, res -> logResponse(req, res))
+                    .thenApply(res -> assertOkStatus(req, res))
+                    .thenApply(this::parsePluginInfo)
+                    .whenComplete((v, t) -> req.reset())
+                    .whenComplete((v, t) -> Arrays.fill(body, (byte) 0));
+        } catch (JsonProcessingException e) {
+            return CompletableFuture.failedFuture(e);
+        }
+    }
+
+    private PluginInfo parsePluginInfo(ClassicHttpResponse response) {
+        try (InputStream is = response.getEntity().getContent()) {
+            return mapper.readValue(is, PluginInfo.class);
+        } catch (IOException e) {
+            log.error("Unable to parse response as JSON", e);
+            throw new RegistrationException(e);
+        }
     }
 
     private ClassicHttpResponse logResponse(HttpUriRequestBase req, ClassicHttpResponse res) {

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -22,9 +22,11 @@ import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -75,6 +77,7 @@ public class Registration {
 
     private final PluginInfo pluginInfo = new PluginInfo();
     private final Set<Consumer<RegistrationEvent>> listeners = new HashSet<>();
+    private volatile boolean refreshCallbacksEnabled;
 
     private volatile URI callback;
     private ScheduledFuture<?> registrationCheckTask;
@@ -184,11 +187,10 @@ public class Registration {
                                                                     if (t != null
                                                                             || !Boolean.TRUE.equals(
                                                                                     v)) {
-                                                                        this.pluginInfo.clear();
                                                                         notify(
                                                                                 RegistrationEvent
                                                                                         .State
-                                                                                        .UNREGISTERED);
+                                                                                        .REFRESHING);
                                                                     }
                                                                     return null;
                                                                 })
@@ -289,97 +291,188 @@ public class Registration {
             }
         }
 
-        currentRegistration =
-                webServer
-                        .generateCredentials(callback)
-                        .thenCompose(v -> cryostat.serverHealth())
-                        .thenCompose(
-                                health -> {
-                                    Semver cryostatSemver = health.cryostatSemver();
-                                    log.debug(
-                                            "Connected to Cryostat server: version {} , build {}",
+        if (!pluginInfo.isInitialized()) {
+            currentRegistration = registerAgent();
+        } else if (!refreshCallbacksEnabled) {
+            currentRegistration = activateRegistrationRefresh();
+        } else {
+            currentRegistration = refreshRegistration();
+        }
+    }
+
+    private CompletableFuture<Void> registerAgent() {
+        return webServer
+                .generateCredentials(callback)
+                .thenCompose(v -> cryostat.serverHealth())
+                .thenCompose(
+                        health -> {
+                            Semver cryostatSemver = health.cryostatSemver();
+                            log.debug(
+                                    "Connected to Cryostat server: version {} , build {}",
+                                    cryostatSemver,
+                                    health.buildInfo().git().hash());
+                            try {
+                                VersionInfo version = VersionInfo.load();
+                                if (!version.validateServerVersion(cryostatSemver)) {
+                                    log.warn(
+                                            "Cryostat server version {} is outside of expected"
+                                                    + " range [{}, {})",
                                             cryostatSemver,
-                                            health.buildInfo().git().hash());
-                                    try {
-                                        VersionInfo version = VersionInfo.load();
-                                        if (!version.validateServerVersion(cryostatSemver)) {
-                                            log.warn(
-                                                    "Cryostat server version {} is outside of"
-                                                            + " expected range [{}, {})",
-                                                    cryostatSemver,
-                                                    version.getServerMin(),
-                                                    version.getServerMax());
-                                        }
-                                    } catch (IOException ioe) {
-                                        log.error("Unable to read versions.properties file", ioe);
-                                    }
+                                            version.getServerMin(),
+                                            version.getServerMax());
+                                }
+                            } catch (IOException ioe) {
+                                log.error("Unable to read versions.properties file", ioe);
+                            }
 
-                                    try (var credentials = webServer.getCredentialsSnapshot()) {
-                                        Set<DiscoveryNode> selfNodes = defineSelf();
-                                        log.trace(
-                                                "registering and publishing self as {}",
-                                                selfNodes.stream()
-                                                        .map(n -> n.getTarget().getConnectUrl())
-                                                        .collect(Collectors.toList()));
-                                        return cryostat.register(callback, credentials, selfNodes);
-                                    } catch (UnknownHostException | URISyntaxException e) {
-                                        return CompletableFuture.failedFuture(e);
-                                    }
-                                })
-                        .whenComplete((plugin, t) -> webServer.clearPlaintextCredentials())
-                        .handle(
-                                (plugin, t) -> {
-                                    if (t != null) {
-                                        return completeRegistrationFailure(t);
-                                    }
+                            try (var credentials = webServer.getCredentialsSnapshot()) {
+                                Set<DiscoveryNode> selfNodes = defineSelf();
+                                log.trace(
+                                        "registering and publishing self as {}",
+                                        selfNodes.stream()
+                                                .map(n -> n.getTarget().getConnectUrl())
+                                                .collect(Collectors.toList()));
+                                return cryostat.register(callback, credentials, selfNodes);
+                            } catch (UnknownHostException | URISyntaxException e) {
+                                return CompletableFuture.failedFuture(e);
+                            }
+                        })
+                .whenComplete((plugin, t) -> webServer.clearPlaintextCredentials())
+                .handle(
+                        (plugin, t) -> {
+                            if (t != null) {
+                                return completeRegistrationFailure(t);
+                            }
+                            if (!isValidRegistration(plugin)) {
+                                return completeRegistrationFailure(
+                                        new IllegalStateException(
+                                                "agent registration returned incomplete plugin"
+                                                        + " information"));
+                            }
 
-                                    webServer.commitPendingCredentials();
-                                    boolean previouslyRegistered = this.pluginInfo.isInitialized();
-                                    this.pluginInfo.copyFrom(plugin);
-                                    log.debug("Registered as {}", this.pluginInfo.getId());
+                            // Cryostat has acknowledged these credentials, so promote them before
+                            // enabling its generic refresh callbacks. If that second request fails,
+                            // the acknowledged credentials must remain valid.
+                            webServer.commitPendingCredentials();
+                            this.pluginInfo.copyFrom(plugin);
+                            this.refreshCallbacksEnabled = false;
+                            log.debug("Registered as {}", this.pluginInfo.getId());
+                            completeRegistrationSuccess();
+                            notify(RegistrationEvent.State.REGISTERED);
+                            notify(RegistrationEvent.State.PUBLISHED);
 
-                                    lastSuccessfulRegistration = Instant.now();
-                                    consecutiveFailures.set(0);
+                            // The Agent endpoint initially schedules GET health pings. Registering
+                            // the same callback through the generic endpoint reuses this plugin and
+                            // changes its existing job to POST token-refresh prompts without
+                            // replacing credentials or publishing discovery nodes.
+                            return activateRegistrationRefresh();
+                        })
+                .thenCompose(f -> f);
+    }
 
-                                    if (circuitState == CircuitState.HALF_OPEN) {
-                                        log.debug("Circuit breaker transitioning to CLOSED");
-                                    }
-                                    circuitState = CircuitState.CLOSED;
+    private CompletableFuture<Void> activateRegistrationRefresh() {
+        return cryostat.activateRegistrationRefresh(callback)
+                .handle(
+                        (plugin, t) -> {
+                            if (t != null) {
+                                if (isRetryableRefreshFailure(t)) {
+                                    return completeRefreshFailure(t);
+                                }
+                                return completeRegistrationFailure(t);
+                            }
+                            if (!isValidRefresh(plugin)) {
+                                return completeRegistrationFailure(
+                                        new IllegalStateException(
+                                                "registration refresh activation returned"
+                                                        + " unexpected plugin information"));
+                            }
 
-                                    log.debug(
-                                            "Registration successful at {}, next attempt"
-                                                    + " allowed after {}",
-                                            lastSuccessfulRegistration,
-                                            lastSuccessfulRegistration.plus(minCooldownDuration));
+                            this.pluginInfo.setToken(plugin.getToken());
+                            this.refreshCallbacksEnabled = true;
+                            log.debug(
+                                    "Enabled registration refresh callbacks for {}",
+                                    this.pluginInfo.getId());
+                            completeRegistrationSuccess();
+                            notify(RegistrationEvent.State.REFRESHED);
+                            return CompletableFuture.<Void>completedFuture(null);
+                        })
+                .thenCompose(f -> f);
+    }
 
-                                    if (previouslyRegistered) {
-                                        notify(RegistrationEvent.State.REFRESHED);
-                                    } else {
-                                        notify(RegistrationEvent.State.REGISTERED);
-                                    }
-                                    notify(RegistrationEvent.State.PUBLISHED);
-                                    return CompletableFuture.<Void>completedFuture(null);
-                                })
-                        .thenCompose(f -> f);
+    private CompletableFuture<Void> refreshRegistration() {
+        return cryostat.refreshRegistration(callback, pluginInfo)
+                .handle(
+                        (plugin, t) -> {
+                            if (t != null) {
+                                if (isRetryableRefreshFailure(t)) {
+                                    return completeRefreshFailure(t);
+                                }
+                                return completeRegistrationFailure(t);
+                            }
+                            if (!isValidRefresh(plugin)) {
+                                return completeRegistrationFailure(
+                                        new IllegalStateException(
+                                                "registration refresh returned no token"));
+                            }
+
+                            this.pluginInfo.setToken(plugin.getToken());
+                            log.debug(
+                                    "Refreshed registration token for {}", this.pluginInfo.getId());
+                            completeRegistrationSuccess();
+                            notify(RegistrationEvent.State.REFRESHED);
+                            return CompletableFuture.<Void>completedFuture(null);
+                        })
+                .thenCompose(f -> f);
+    }
+
+    private boolean isValidRegistration(PluginInfo plugin) {
+        return plugin != null
+                && StringUtils.isNotBlank(plugin.getId())
+                && StringUtils.isNotBlank(plugin.getToken());
+    }
+
+    private boolean isValidRefresh(PluginInfo plugin) {
+        return isValidRegistration(plugin) && Objects.equals(pluginInfo.getId(), plugin.getId());
+    }
+
+    private boolean isRetryableRefreshFailure(Throwable t) {
+        Throwable cause = t;
+        while (cause instanceof CompletionException && cause.getCause() != null) {
+            cause = cause.getCause();
+        }
+        if (!(cause instanceof HttpException)) {
+            return true;
+        }
+        HttpException httpException = (HttpException) cause;
+        int statusCode = httpException.statusCode();
+        return statusCode == 408 || statusCode == 425 || statusCode == 429 || statusCode >= 500;
+    }
+
+    private void completeRegistrationSuccess() {
+        lastSuccessfulRegistration = Instant.now();
+        consecutiveFailures.set(0);
+
+        if (circuitState == CircuitState.HALF_OPEN) {
+            log.debug("Circuit breaker transitioning to CLOSED");
+        }
+        circuitState = CircuitState.CLOSED;
+
+        log.debug(
+                "Registration successful at {}, next attempt allowed after {}",
+                lastSuccessfulRegistration,
+                lastSuccessfulRegistration.plus(minCooldownDuration));
     }
 
     private CompletableFuture<Void> completeRegistrationFailure(Throwable t) {
         webServer.discardPendingCredentials();
+        this.refreshCallbacksEnabled = false;
         this.pluginInfo.clear();
 
         int failures = consecutiveFailures.incrementAndGet();
         long backoffMs = calculateBackoffMs();
         Duration cooldown = Duration.ofMillis(backoffMs);
 
-        if (circuitState == CircuitState.CLOSED && failures >= circuitBreakerThreshold) {
-            log.warn("Circuit breaker transitioning to OPEN after {} failures", failures);
-            circuitState = CircuitState.OPEN;
-            circuitOpenedAt = Instant.now();
-        } else if (circuitState == CircuitState.HALF_OPEN) {
-            log.warn("Circuit breaker transitioning back to OPEN");
-            circuitState = CircuitState.OPEN;
-            circuitOpenedAt = Instant.now();
-        }
+        updateCircuitAfterFailure(failures);
 
         log.error(
                 "Registration failure (attempt {}, circuit state: {}, cooldown: {})",
@@ -394,6 +487,45 @@ public class Registration {
             enterCooldown(cooldown);
         }
         return CompletableFuture.completedFuture(null);
+    }
+
+    private void updateCircuitAfterFailure(int failures) {
+        if (circuitState == CircuitState.CLOSED && failures >= circuitBreakerThreshold) {
+            log.warn("Circuit breaker transitioning to OPEN after {} failures", failures);
+            circuitState = CircuitState.OPEN;
+            circuitOpenedAt = Instant.now();
+        } else if (circuitState == CircuitState.HALF_OPEN) {
+            log.warn("Circuit breaker transitioning back to OPEN");
+            circuitState = CircuitState.OPEN;
+            circuitOpenedAt = Instant.now();
+        }
+    }
+
+    private CompletableFuture<Void> completeRefreshFailure(Throwable t) {
+        int failures = consecutiveFailures.incrementAndGet();
+        long backoffMs = calculateRefreshBackoffMs();
+
+        updateCircuitAfterFailure(failures);
+        log.warn(
+                "Registration refresh failure (attempt {}, circuit state: {}, retry in {} ms)",
+                failures,
+                circuitState,
+                backoffMs,
+                t);
+        executor.schedule(
+                () -> notify(RegistrationEvent.State.REFRESHING), backoffMs, TimeUnit.MILLISECONDS);
+        return CompletableFuture.completedFuture(null);
+    }
+
+    private long calculateRefreshBackoffMs() {
+        int failures = consecutiveFailures.get();
+        double jitter = 1.0 + (random.nextDouble() * 2 - 1) * retryBackoffJitterFactor;
+        long backoff =
+                (long)
+                        (registrationRetryMs
+                                * Math.pow(backoffMultiplier, Math.min(failures - 1, 10)));
+        backoff = Math.min(backoff, maxBackoffMs);
+        return (long) (backoff * jitter);
     }
 
     private long calculateBackoffMs() {
@@ -609,6 +741,7 @@ public class Registration {
                                         "Deregistered from Cryostat discovery plugin [{}]",
                                         this.pluginInfo.getId());
                             }
+                            this.refreshCallbacksEnabled = false;
                             this.pluginInfo.clear();
                             notify(RegistrationEvent.State.UNREGISTERED);
                             return null;

--- a/src/main/java/io/cryostat/agent/Registration.java
+++ b/src/main/java/io/cryostat/agent/Registration.java
@@ -76,6 +76,7 @@ public class Registration {
     private final Random random;
 
     private final PluginInfo pluginInfo = new PluginInfo();
+    private final Object pluginInfoLock = new Object();
     private final Set<Consumer<RegistrationEvent>> listeners = new HashSet<>();
     private volatile boolean refreshCallbacksEnabled;
 
@@ -181,7 +182,8 @@ public class Registration {
                             this.registrationCheckTask =
                                     executor.scheduleAtFixedRate(
                                             () -> {
-                                                cryostat.checkRegistration(pluginInfo)
+                                                PluginInfo registeredPlugin = pluginInfoSnapshot();
+                                                cryostat.checkRegistration(registeredPlugin)
                                                         .handle(
                                                                 (v, t) -> {
                                                                     if (t != null
@@ -291,12 +293,13 @@ public class Registration {
             }
         }
 
-        if (!pluginInfo.isInitialized()) {
+        PluginInfo registeredPlugin = pluginInfoSnapshot();
+        if (!registeredPlugin.isInitialized()) {
             currentRegistration = registerAgent();
         } else if (!refreshCallbacksEnabled) {
             currentRegistration = activateRegistrationRefresh();
         } else {
-            currentRegistration = refreshRegistration();
+            currentRegistration = refreshRegistration(registeredPlugin);
         }
     }
 
@@ -354,9 +357,9 @@ public class Registration {
                             // enabling its generic refresh callbacks. If that second request fails,
                             // the acknowledged credentials must remain valid.
                             webServer.commitPendingCredentials();
-                            this.pluginInfo.copyFrom(plugin);
+                            copyPluginInfo(plugin);
                             this.refreshCallbacksEnabled = false;
-                            log.debug("Registered as {}", this.pluginInfo.getId());
+                            log.debug("Registered as {}", plugin.getId());
                             completeRegistrationSuccess();
                             notify(RegistrationEvent.State.REGISTERED);
                             notify(RegistrationEvent.State.PUBLISHED);
@@ -380,18 +383,17 @@ public class Registration {
                                 }
                                 return completeRegistrationFailure(t);
                             }
-                            if (!isValidRefresh(plugin)) {
+                            if (!updatePluginInfoToken(plugin)) {
                                 return completeRegistrationFailure(
                                         new IllegalStateException(
                                                 "registration refresh activation returned"
                                                         + " unexpected plugin information"));
                             }
 
-                            this.pluginInfo.setToken(plugin.getToken());
                             this.refreshCallbacksEnabled = true;
                             log.debug(
                                     "Enabled registration refresh callbacks for {}",
-                                    this.pluginInfo.getId());
+                                    plugin.getId());
                             completeRegistrationSuccess();
                             notify(RegistrationEvent.State.REFRESHED);
                             return CompletableFuture.<Void>completedFuture(null);
@@ -399,8 +401,8 @@ public class Registration {
                 .thenCompose(f -> f);
     }
 
-    private CompletableFuture<Void> refreshRegistration() {
-        return cryostat.refreshRegistration(callback, pluginInfo)
+    private CompletableFuture<Void> refreshRegistration(PluginInfo registeredPlugin) {
+        return cryostat.refreshRegistration(callback, registeredPlugin)
                 .handle(
                         (plugin, t) -> {
                             if (t != null) {
@@ -409,15 +411,13 @@ public class Registration {
                                 }
                                 return completeRegistrationFailure(t);
                             }
-                            if (!isValidRefresh(plugin)) {
+                            if (!updatePluginInfoToken(plugin)) {
                                 return completeRegistrationFailure(
                                         new IllegalStateException(
                                                 "registration refresh returned no token"));
                             }
 
-                            this.pluginInfo.setToken(plugin.getToken());
-                            log.debug(
-                                    "Refreshed registration token for {}", this.pluginInfo.getId());
+                            log.debug("Refreshed registration token for {}", plugin.getId());
                             completeRegistrationSuccess();
                             notify(RegistrationEvent.State.REFRESHED);
                             return CompletableFuture.<Void>completedFuture(null);
@@ -431,8 +431,37 @@ public class Registration {
                 && StringUtils.isNotBlank(plugin.getToken());
     }
 
-    private boolean isValidRefresh(PluginInfo plugin) {
-        return isValidRegistration(plugin) && Objects.equals(pluginInfo.getId(), plugin.getId());
+    private boolean updatePluginInfoToken(PluginInfo plugin) {
+        if (!isValidRegistration(plugin)) {
+            return false;
+        }
+        synchronized (pluginInfoLock) {
+            if (!Objects.equals(pluginInfo.getId(), plugin.getId())) {
+                return false;
+            }
+            pluginInfo.setToken(plugin.getToken());
+            return true;
+        }
+    }
+
+    private void copyPluginInfo(PluginInfo plugin) {
+        synchronized (pluginInfoLock) {
+            pluginInfo.copyFrom(plugin);
+        }
+    }
+
+    private void clearPluginInfo() {
+        synchronized (pluginInfoLock) {
+            pluginInfo.clear();
+        }
+    }
+
+    private PluginInfo pluginInfoSnapshot() {
+        synchronized (pluginInfoLock) {
+            PluginInfo snapshot = new PluginInfo();
+            snapshot.copyFrom(pluginInfo);
+            return snapshot;
+        }
     }
 
     private boolean isRetryableRefreshFailure(Throwable t) {
@@ -464,12 +493,15 @@ public class Registration {
     }
 
     private CompletableFuture<Void> completeRegistrationFailure(Throwable t) {
+        return completeRegistrationFailure(t, consecutiveFailures.incrementAndGet());
+    }
+
+    private CompletableFuture<Void> completeRegistrationFailure(Throwable t, int failures) {
         webServer.discardPendingCredentials();
         this.refreshCallbacksEnabled = false;
-        this.pluginInfo.clear();
+        clearPluginInfo();
 
-        int failures = consecutiveFailures.incrementAndGet();
-        long backoffMs = calculateBackoffMs();
+        long backoffMs = calculateBackoffMs(failures, true);
         Duration cooldown = Duration.ofMillis(backoffMs);
 
         updateCircuitAfterFailure(failures);
@@ -482,7 +514,10 @@ public class Registration {
                 t);
 
         if (minCooldownDuration.isZero()) {
-            executor.schedule(this::tryRegister, backoffMs, TimeUnit.MILLISECONDS);
+            executor.schedule(
+                    () -> notify(RegistrationEvent.State.UNREGISTERED),
+                    backoffMs,
+                    TimeUnit.MILLISECONDS);
         } else {
             enterCooldown(cooldown);
         }
@@ -503,7 +538,15 @@ public class Registration {
 
     private CompletableFuture<Void> completeRefreshFailure(Throwable t) {
         int failures = consecutiveFailures.incrementAndGet();
-        long backoffMs = calculateRefreshBackoffMs();
+        if (failures >= circuitBreakerThreshold) {
+            log.warn(
+                    "Registration refresh failed {} consecutive times, falling back to full"
+                            + " registration",
+                    failures);
+            return completeRegistrationFailure(t, failures);
+        }
+
+        long backoffMs = calculateBackoffMs(failures, false);
 
         updateCircuitAfterFailure(failures);
         log.warn(
@@ -517,19 +560,7 @@ public class Registration {
         return CompletableFuture.completedFuture(null);
     }
 
-    private long calculateRefreshBackoffMs() {
-        int failures = consecutiveFailures.get();
-        double jitter = 1.0 + (random.nextDouble() * 2 - 1) * retryBackoffJitterFactor;
-        long backoff =
-                (long)
-                        (registrationRetryMs
-                                * Math.pow(backoffMultiplier, Math.min(failures - 1, 10)));
-        backoff = Math.min(backoff, maxBackoffMs);
-        return (long) (backoff * jitter);
-    }
-
-    private long calculateBackoffMs() {
-        int failures = consecutiveFailures.get();
+    private long calculateBackoffMs(int failures, boolean applyCooldownFloor) {
         if (failures == 0) {
             return registrationRetryMs;
         }
@@ -541,7 +572,9 @@ public class Registration {
                                 * Math.pow(backoffMultiplier, Math.min(failures - 1, 10)));
         backoff = Math.min(backoff, maxBackoffMs);
         backoff = (long) (backoff * jitter);
-        backoff = Math.max(backoff, minCooldownDuration.toMillis());
+        if (applyCooldownFloor) {
+            backoff = Math.max(backoff, minCooldownDuration.toMillis());
+        }
 
         return backoff;
     }
@@ -725,24 +758,25 @@ public class Registration {
     }
 
     CompletableFuture<Void> deregister() {
-        if (!this.pluginInfo.isInitialized()) {
+        PluginInfo registeredPlugin = pluginInfoSnapshot();
+        if (!registeredPlugin.isInitialized()) {
             log.warn("Deregistration requested before registration complete!");
             return CompletableFuture.completedFuture(null);
         }
-        return cryostat.deregister(pluginInfo)
+        return cryostat.deregister(registeredPlugin)
                 .handle(
                         (n, t) -> {
                             if (t != null) {
                                 log.warn(
                                         "Failed to deregister as Cryostat discovery plugin [{}]",
-                                        this.pluginInfo.getId());
+                                        registeredPlugin.getId());
                             } else {
                                 log.debug(
                                         "Deregistered from Cryostat discovery plugin [{}]",
-                                        this.pluginInfo.getId());
+                                        registeredPlugin.getId());
                             }
                             this.refreshCallbacksEnabled = false;
-                            this.pluginInfo.clear();
+                            clearPluginInfo();
                             notify(RegistrationEvent.State.UNREGISTERED);
                             return null;
                         });
@@ -772,6 +806,6 @@ public class Registration {
     }
 
     PluginInfo getPluginInfo() {
-        return pluginInfo;
+        return pluginInfoSnapshot();
     }
 }

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -20,12 +20,14 @@ import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -185,6 +187,29 @@ class CryostatClientTest {
         assertFalse(requestBody.has("token"));
         assertFalse(requestBody.has("credential"));
         assertFalse(requestBody.has("nodes"));
+    }
+
+    @Test
+    void testRefreshRegistrationRejectsResponseWithoutPluginInfo() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        when(http.execute(any(HttpHost.class), any(HttpPost.class))).thenReturn(response);
+        when(response.getCode()).thenReturn(204);
+        when(response.getEntity()).thenReturn(null);
+
+        ExecutionException exception =
+                assertThrows(
+                        ExecutionException.class,
+                        () ->
+                                client.refreshRegistration(
+                                                callback,
+                                                new PluginInfo(
+                                                        "plugin-id", "current-token", List.of()))
+                                        .get());
+
+        RegistrationException registrationException =
+                assertInstanceOf(RegistrationException.class, exception.getCause());
+        IOException cause = assertInstanceOf(IOException.class, registrationException.getCause());
+        assertEquals("Response (204) contained no plugin information", cause.getMessage());
     }
 
     @Test

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -137,6 +137,91 @@ class CryostatClientTest {
     }
 
     @Test
+    void testRefreshRegistrationPostsOnlyExistingRegistrationIdentity() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        AtomicReference<String> submittedRequestBody = new AtomicReference<>();
+
+        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
+                .thenAnswer(
+                        invocation -> {
+                            HttpPost request = invocation.getArgument(1);
+                            ByteArrayOutputStream out = new ByteArrayOutputStream();
+                            request.getEntity().writeTo(out);
+                            submittedRequestBody.set(out.toString(StandardCharsets.UTF_8));
+                            return response;
+                        });
+        when(response.getCode()).thenReturn(200);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent())
+                .thenReturn(
+                        new StringEntity(
+                                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}")
+                                .getContent());
+
+        PluginInfo refreshed =
+                client.refreshRegistration(
+                                callback, new PluginInfo("plugin-id", "current-token", List.of()))
+                        .get();
+
+        assertEquals("plugin-id", refreshed.getId());
+        assertEquals("new-token", refreshed.getToken());
+
+        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+        verify(http).execute(any(HttpHost.class), requestCaptor.capture());
+        assertEquals("/api/v4/discovery", requestCaptor.getValue().getUri().getPath());
+
+        JsonNode requestBody = mapper.readTree(submittedRequestBody.get());
+        assertEquals("plugin-id", requestBody.get("id").asText());
+        assertEquals("current-token", requestBody.get("token").asText());
+        assertEquals(REALM, requestBody.get("realm").asText());
+        assertEquals(callback.toString(), requestBody.get("callback").asText());
+        assertEquals(4, requestBody.size());
+        assertFalse(requestBody.has("credential"));
+        assertFalse(requestBody.has("nodes"));
+    }
+
+    @Test
+    void testActivateRegistrationRefreshPostsOnlyCallbackIdentity() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        AtomicReference<String> submittedRequestBody = new AtomicReference<>();
+
+        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
+                .thenAnswer(
+                        invocation -> {
+                            HttpPost request = invocation.getArgument(1);
+                            ByteArrayOutputStream out = new ByteArrayOutputStream();
+                            request.getEntity().writeTo(out);
+                            submittedRequestBody.set(out.toString(StandardCharsets.UTF_8));
+                            return response;
+                        });
+        when(response.getCode()).thenReturn(200);
+        when(response.getEntity()).thenReturn(responseEntity);
+        when(responseEntity.getContent())
+                .thenReturn(
+                        new StringEntity(
+                                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}")
+                                .getContent());
+
+        PluginInfo activated = client.activateRegistrationRefresh(callback).get();
+
+        assertEquals("plugin-id", activated.getId());
+        assertEquals("new-token", activated.getToken());
+
+        ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
+        verify(http).execute(any(HttpHost.class), requestCaptor.capture());
+        assertEquals("/api/v4/discovery", requestCaptor.getValue().getUri().getPath());
+
+        JsonNode requestBody = mapper.readTree(submittedRequestBody.get());
+        assertEquals(REALM, requestBody.get("realm").asText());
+        assertEquals(callback.toString(), requestBody.get("callback").asText());
+        assertEquals(2, requestBody.size());
+        assertFalse(requestBody.has("id"));
+        assertFalse(requestBody.has("token"));
+        assertFalse(requestBody.has("credential"));
+        assertFalse(requestBody.has("nodes"));
+    }
+
+    @Test
     void testRegisterIncludesRealmInCredentialMatchExpression() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
         JsonNode requestBody = captureRegistrationRequest(client, callback);

--- a/src/test/java/io/cryostat/agent/CryostatClientTest.java
+++ b/src/test/java/io/cryostat/agent/CryostatClientTest.java
@@ -24,6 +24,7 @@ import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -93,40 +94,30 @@ class CryostatClientTest {
     @Test
     void testRegisterPostsAgentRegistration() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
-        AtomicReference<String> submittedRequestBody = new AtomicReference<>();
-
-        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenAnswer(
-                        invocation -> {
-                            HttpPost request = invocation.getArgument(1);
-                            ByteArrayOutputStream out = new ByteArrayOutputStream();
-                            request.getEntity().writeTo(out);
-                            submittedRequestBody.set(out.toString(StandardCharsets.UTF_8));
-                            return response;
+        JsonNode requestBody =
+                capturePostBody(
+                        "{\"id\":\"plugin-id\",\"token\":\"token\",\"env\":[]}",
+                        () -> {
+                            PluginInfo pluginInfo =
+                                    client.register(
+                                                    callback,
+                                                    new CredentialsSnapshot(
+                                                            "testuser",
+                                                            "testpass"
+                                                                    .getBytes(
+                                                                            StandardCharsets
+                                                                                    .US_ASCII)),
+                                                    List.of(discoveryNode(callback)))
+                                            .get();
+                            assertEquals("plugin-id", pluginInfo.getId());
+                            assertEquals("token", pluginInfo.getToken());
+                            return pluginInfo;
                         });
-        when(response.getCode()).thenReturn(200);
-        when(response.getEntity()).thenReturn(responseEntity);
-        when(responseEntity.getContent())
-                .thenReturn(
-                        new StringEntity("{\"id\":\"plugin-id\",\"token\":\"token\",\"env\":[]}")
-                                .getContent());
-
-        PluginInfo pluginInfo =
-                client.register(
-                                callback,
-                                new CredentialsSnapshot(
-                                        "testuser", "testpass".getBytes(StandardCharsets.US_ASCII)),
-                                List.of(discoveryNode(callback)))
-                        .get();
-
-        assertEquals("plugin-id", pluginInfo.getId());
-        assertEquals("token", pluginInfo.getToken());
 
         ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
         verify(http).execute(any(HttpHost.class), requestCaptor.capture());
         assertEquals("/api/v4.3/discovery/agents", requestCaptor.getValue().getUri().getPath());
 
-        JsonNode requestBody = mapper.readTree(submittedRequestBody.get());
         assertEquals(REALM, requestBody.get("realm").asText());
         assertEquals(callback.toString(), requestBody.get("callback").asText());
         assertEquals("MERGE", requestBody.get("fillStrategy").asText());
@@ -139,38 +130,27 @@ class CryostatClientTest {
     @Test
     void testRefreshRegistrationPostsOnlyExistingRegistrationIdentity() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
-        AtomicReference<String> submittedRequestBody = new AtomicReference<>();
-
-        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenAnswer(
-                        invocation -> {
-                            HttpPost request = invocation.getArgument(1);
-                            ByteArrayOutputStream out = new ByteArrayOutputStream();
-                            request.getEntity().writeTo(out);
-                            submittedRequestBody.set(out.toString(StandardCharsets.UTF_8));
-                            return response;
+        JsonNode requestBody =
+                capturePostBody(
+                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}",
+                        () -> {
+                            PluginInfo refreshed =
+                                    client.refreshRegistration(
+                                                    callback,
+                                                    new PluginInfo(
+                                                            "plugin-id",
+                                                            "current-token",
+                                                            List.of()))
+                                            .get();
+                            assertEquals("plugin-id", refreshed.getId());
+                            assertEquals("new-token", refreshed.getToken());
+                            return refreshed;
                         });
-        when(response.getCode()).thenReturn(200);
-        when(response.getEntity()).thenReturn(responseEntity);
-        when(responseEntity.getContent())
-                .thenReturn(
-                        new StringEntity(
-                                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}")
-                                .getContent());
-
-        PluginInfo refreshed =
-                client.refreshRegistration(
-                                callback, new PluginInfo("plugin-id", "current-token", List.of()))
-                        .get();
-
-        assertEquals("plugin-id", refreshed.getId());
-        assertEquals("new-token", refreshed.getToken());
 
         ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
         verify(http).execute(any(HttpHost.class), requestCaptor.capture());
         assertEquals("/api/v4/discovery", requestCaptor.getValue().getUri().getPath());
 
-        JsonNode requestBody = mapper.readTree(submittedRequestBody.get());
         assertEquals("plugin-id", requestBody.get("id").asText());
         assertEquals("current-token", requestBody.get("token").asText());
         assertEquals(REALM, requestBody.get("realm").asText());
@@ -183,35 +163,21 @@ class CryostatClientTest {
     @Test
     void testActivateRegistrationRefreshPostsOnlyCallbackIdentity() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
-        AtomicReference<String> submittedRequestBody = new AtomicReference<>();
-
-        when(http.execute(any(HttpHost.class), any(HttpPost.class)))
-                .thenAnswer(
-                        invocation -> {
-                            HttpPost request = invocation.getArgument(1);
-                            ByteArrayOutputStream out = new ByteArrayOutputStream();
-                            request.getEntity().writeTo(out);
-                            submittedRequestBody.set(out.toString(StandardCharsets.UTF_8));
-                            return response;
+        JsonNode requestBody =
+                capturePostBody(
+                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}",
+                        () -> {
+                            PluginInfo activated =
+                                    client.activateRegistrationRefresh(callback).get();
+                            assertEquals("plugin-id", activated.getId());
+                            assertEquals("new-token", activated.getToken());
+                            return activated;
                         });
-        when(response.getCode()).thenReturn(200);
-        when(response.getEntity()).thenReturn(responseEntity);
-        when(responseEntity.getContent())
-                .thenReturn(
-                        new StringEntity(
-                                        "{\"id\":\"plugin-id\",\"token\":\"new-token\",\"env\":[]}")
-                                .getContent());
-
-        PluginInfo activated = client.activateRegistrationRefresh(callback).get();
-
-        assertEquals("plugin-id", activated.getId());
-        assertEquals("new-token", activated.getToken());
 
         ArgumentCaptor<HttpPost> requestCaptor = ArgumentCaptor.forClass(HttpPost.class);
         verify(http).execute(any(HttpHost.class), requestCaptor.capture());
         assertEquals("/api/v4/discovery", requestCaptor.getValue().getUri().getPath());
 
-        JsonNode requestBody = mapper.readTree(submittedRequestBody.get());
         assertEquals(REALM, requestBody.get("realm").asText());
         assertEquals(callback.toString(), requestBody.get("callback").asText());
         assertEquals(2, requestBody.size());
@@ -261,6 +227,19 @@ class CryostatClientTest {
 
     private JsonNode captureRegistrationRequest(CryostatClient client, URI callback)
             throws Exception {
+        return capturePostBody(
+                "{\"id\":\"plugin-id\",\"token\":\"token\",\"env\":[]}",
+                () ->
+                        client.register(
+                                        callback,
+                                        new CredentialsSnapshot(
+                                                "testuser",
+                                                "testpass".getBytes(StandardCharsets.US_ASCII)),
+                                        List.of(discoveryNode(callback)))
+                                .get());
+    }
+
+    private JsonNode capturePostBody(String responseJson, Callable<?> operation) throws Exception {
         AtomicReference<String> submittedRequestBody = new AtomicReference<>();
 
         when(http.execute(any(HttpHost.class), any(HttpPost.class)))
@@ -274,17 +253,9 @@ class CryostatClientTest {
                         });
         when(response.getCode()).thenReturn(200);
         when(response.getEntity()).thenReturn(responseEntity);
-        when(responseEntity.getContent())
-                .thenReturn(
-                        new StringEntity("{\"id\":\"plugin-id\",\"token\":\"token\",\"env\":[]}")
-                                .getContent());
+        when(responseEntity.getContent()).thenReturn(new StringEntity(responseJson).getContent());
 
-        client.register(
-                        callback,
-                        new CredentialsSnapshot(
-                                "testuser", "testpass".getBytes(StandardCharsets.US_ASCII)),
-                        List.of(discoveryNode(callback)))
-                .get();
+        operation.call();
 
         return mapper.readTree(submittedRequestBody.get());
     }

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -651,7 +651,7 @@ class RegistrationTest {
                         MAX_BACKOFF_MS,
                         BACKOFF_MULTIPLIER,
                         2,
-                        Duration.ZERO,
+                        Duration.ofMillis(-1),
                         MIN_COOLDOWN_DURATION,
                         COOLDOWN_JITTER_FACTOR,
                         RETRY_BACKOFF_JITTER_FACTOR,

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.*;
 
 import java.net.URI;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -28,6 +29,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 
+import io.cryostat.agent.Registration.RegistrationEvent.State;
 import io.cryostat.agent.model.PluginInfo;
 import io.cryostat.agent.model.ServerHealth;
 import io.cryostat.agent.util.AppNameResolver;
@@ -487,32 +489,218 @@ class RegistrationTest {
     @Test
     void testSuccessfulRegistrationCommitsPendingCredentials() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
-        when(callbackResolver.determineSelfCallback()).thenReturn(callback);
-        when(appNameResolver.extractFromJavaCommand()).thenReturn("test.Main");
-        when(cryostat.serverHealth())
-                .thenReturn(
-                        CompletableFuture.completedFuture(
-                                new ServerHealth(
-                                        "4.3.0",
-                                        new ServerHealth.BuildInfo(
-                                                new ServerHealth.GitInfo("test-hash")))));
-        when(cryostat.register(eq(callback), any(), anyCollection()))
-                .thenReturn(
-                        CompletableFuture.completedFuture(
-                                new PluginInfo("plugin-id", "plugin-token", List.of())));
-        doAnswer(
-                        invocation -> {
-                            invocation.getArgument(0, Runnable.class).run();
-                            return scheduledFuture;
-                        })
-                .when(executor)
-                .submit(any(Runnable.class));
+        stubSuccessfulInitialRegistration(callback, "plugin-id", "plugin-token");
+        runSubmittedTasksImmediately();
 
         registration.start();
 
         verify(webServer).commitPendingCredentials();
         verify(webServer, never()).discardPendingCredentials();
+        verify(cryostat).activateRegistrationRefresh(callback);
+        verify(cryostat, never()).refreshRegistration(any(), any());
         assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("bootstrap-token", registration.getPluginInfo().getToken());
+    }
+
+    @Test
+    void testInvalidPeriodicCheckRefreshesTokenWithoutReplacingCredentials() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        stubSuccessfulInitialRegistration(callback, "plugin-id", "expired-token");
+        when(cryostat.checkRegistration(any(PluginInfo.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(cryostat.refreshRegistration(eq(callback), any(PluginInfo.class)))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "new-token", List.of())));
+        runSubmittedTasksImmediately();
+        List<State> events = new ArrayList<>();
+        registration.addRegistrationListener(evt -> events.add(evt.state));
+
+        registration.start();
+        ArgumentCaptor<Runnable> checkTask = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor)
+                .scheduleAtFixedRate(
+                        checkTask.capture(),
+                        eq((long) REGISTRATION_CHECK_MS),
+                        eq((long) REGISTRATION_CHECK_MS),
+                        eq(TimeUnit.MILLISECONDS));
+
+        checkTask.getValue().run();
+
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("new-token", registration.getPluginInfo().getToken());
+        verify(cryostat).checkRegistration(any(PluginInfo.class));
+        verify(cryostat).activateRegistrationRefresh(callback);
+        verify(cryostat).refreshRegistration(eq(callback), any(PluginInfo.class));
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+        verify(cryostat, times(1)).serverHealth();
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(webServer, times(1)).commitPendingCredentials();
+        verify(webServer, never()).discardPendingCredentials();
+        assertTrue(events.contains(State.REFRESHING));
+        assertTrue(events.contains(State.REFRESHED));
+        assertEquals(2, events.stream().filter(State.REFRESHED::equals).count());
+    }
+
+    @Test
+    void testRetryableActivationFailurePreservesRegistrationAndRetriesActivationOnly()
+            throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        stubSuccessfulInitialRegistration(callback, "plugin-id", "initial-token");
+        when(cryostat.activateRegistrationRefresh(callback))
+                .thenReturn(
+                        CompletableFuture.failedFuture(new HttpException(503, callback)),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "retried-token", List.of())));
+        when(random.nextDouble()).thenReturn(0.5);
+        doReturn(scheduledFuture)
+                .when(executor)
+                .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        runSubmittedTasksImmediately();
+
+        registration.start();
+
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("initial-token", registration.getPluginInfo().getToken());
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+        verify(webServer, never()).discardPendingCredentials();
+
+        ArgumentCaptor<Runnable> retryTask = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor)
+                .schedule(
+                        retryTask.capture(),
+                        eq((long) REGISTRATION_RETRY_MS),
+                        eq(TimeUnit.MILLISECONDS));
+        retryTask.getValue().run();
+
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("retried-token", registration.getPluginInfo().getToken());
+        verify(cryostat, times(2)).activateRegistrationRefresh(callback);
+        verify(cryostat, never()).refreshRegistration(any(), any());
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+    }
+
+    @Test
+    void testRetryableTokenRefreshFailurePreservesRegistrationAndRetriesRefreshOnly()
+            throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        stubSuccessfulInitialRegistration(callback, "plugin-id", "initial-token");
+        when(cryostat.refreshRegistration(eq(callback), any(PluginInfo.class)))
+                .thenReturn(
+                        CompletableFuture.failedFuture(new HttpException(503, callback)),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "retried-token", List.of())));
+        when(random.nextDouble()).thenReturn(0.5);
+        doReturn(scheduledFuture)
+                .when(executor)
+                .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        runSubmittedTasksImmediately();
+
+        registration.start();
+        registration.notify(State.REFRESHING);
+
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("bootstrap-token", registration.getPluginInfo().getToken());
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+        verify(webServer, never()).discardPendingCredentials();
+
+        ArgumentCaptor<Runnable> retryTask = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor)
+                .schedule(
+                        retryTask.capture(),
+                        eq((long) REGISTRATION_RETRY_MS),
+                        eq(TimeUnit.MILLISECONDS));
+        retryTask.getValue().run();
+
+        assertEquals("plugin-id", registration.getPluginInfo().getId());
+        assertEquals("retried-token", registration.getPluginInfo().getToken());
+        verify(cryostat).activateRegistrationRefresh(callback);
+        verify(cryostat, times(2)).refreshRegistration(eq(callback), any(PluginInfo.class));
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+    }
+
+    @Test
+    void testTerminalRefreshFailureFallsBackToFullRecoveryRegistration() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        when(callbackResolver.determineSelfCallback()).thenReturn(callback);
+        when(appNameResolver.extractFromJavaCommand()).thenReturn("test.Main");
+        when(cryostat.serverHealth()).thenReturn(CompletableFuture.completedFuture(serverHealth()));
+        when(cryostat.register(eq(callback), any(), anyCollection()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "expired-token", List.of())),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("recovered-id", "recovered-token", List.of())));
+        when(cryostat.checkRegistration(any(PluginInfo.class)))
+                .thenReturn(CompletableFuture.completedFuture(false));
+        when(cryostat.activateRegistrationRefresh(callback))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "bootstrap-token", List.of())),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo(
+                                        "recovered-id", "recovered-bootstrap-token", List.of())));
+        when(cryostat.refreshRegistration(eq(callback), any(PluginInfo.class)))
+                .thenReturn(CompletableFuture.failedFuture(new HttpException(400, callback)));
+        when(random.nextDouble()).thenReturn(0.5);
+        runSubmittedTasksImmediately();
+
+        registration.start();
+        ArgumentCaptor<Runnable> checkTask = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor)
+                .scheduleAtFixedRate(
+                        checkTask.capture(),
+                        eq((long) REGISTRATION_CHECK_MS),
+                        eq((long) REGISTRATION_CHECK_MS),
+                        eq(TimeUnit.MILLISECONDS));
+        checkTask.getValue().run();
+
+        assertFalse(registration.getPluginInfo().isInitialized());
+        ArgumentCaptor<Runnable> recoveryTask = ArgumentCaptor.forClass(Runnable.class);
+        verify(executor)
+                .schedule(
+                        recoveryTask.capture(),
+                        eq((long) REGISTRATION_RETRY_MS),
+                        eq(TimeUnit.MILLISECONDS));
+        recoveryTask.getValue().run();
+
+        assertEquals("recovered-id", registration.getPluginInfo().getId());
+        assertEquals("recovered-bootstrap-token", registration.getPluginInfo().getToken());
+        verify(cryostat, times(2)).activateRegistrationRefresh(callback);
+        verify(cryostat).refreshRegistration(eq(callback), any(PluginInfo.class));
+        verify(cryostat, times(2)).register(eq(callback), any(), anyCollection());
+        verify(webServer, times(2)).generateCredentials(callback);
+        verify(webServer, times(2)).commitPendingCredentials();
+        verify(webServer).discardPendingCredentials();
+    }
+
+    @Test
+    void testOverlappingRefreshAttemptsAreSerialized() {
+        URI callback = URI.create("http://agent.example.com:9977");
+        try {
+            stubSuccessfulInitialRegistration(callback, "plugin-id", "old-token");
+        } catch (Exception e) {
+            throw new AssertionError(e);
+        }
+        runSubmittedTasksImmediately();
+        registration.start();
+
+        CompletableFuture<PluginInfo> refresh = new CompletableFuture<>();
+        when(cryostat.refreshRegistration(eq(callback), any(PluginInfo.class))).thenReturn(refresh);
+
+        registration.notify(State.REFRESHING);
+        registration.notify(State.REFRESHING);
+
+        verify(cryostat, times(1)).refreshRegistration(eq(callback), any(PluginInfo.class));
+        verify(webServer, times(1)).generateCredentials(callback);
+        verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
+
+        refresh.complete(new PluginInfo("plugin-id", "new-token", List.of()));
+        assertEquals("new-token", registration.getPluginInfo().getToken());
     }
 
     @Test
@@ -577,5 +765,36 @@ class RegistrationTest {
 
         verify(webServer).exitCooldownMode();
         verify(cryostat, times(1)).serverHealth();
+    }
+
+    private void stubSuccessfulInitialRegistration(
+            URI callback, String pluginId, String pluginToken) throws Exception {
+        when(callbackResolver.determineSelfCallback()).thenReturn(callback);
+        when(appNameResolver.extractFromJavaCommand()).thenReturn("test.Main");
+        when(cryostat.serverHealth()).thenReturn(CompletableFuture.completedFuture(serverHealth()));
+        when(cryostat.register(eq(callback), any(), anyCollection()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo(pluginId, pluginToken, List.of())));
+        lenient()
+                .when(cryostat.activateRegistrationRefresh(callback))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo(pluginId, "bootstrap-token", List.of())));
+    }
+
+    private ServerHealth serverHealth() {
+        return new ServerHealth(
+                "4.3.0", new ServerHealth.BuildInfo(new ServerHealth.GitInfo("test-hash")));
+    }
+
+    private void runSubmittedTasksImmediately() {
+        doAnswer(
+                        invocation -> {
+                            invocation.getArgument(0, Runnable.class).run();
+                            return scheduledFuture;
+                        })
+                .when(executor)
+                .submit(any(Runnable.class));
     }
 }

--- a/src/test/java/io/cryostat/agent/RegistrationTest.java
+++ b/src/test/java/io/cryostat/agent/RegistrationTest.java
@@ -529,9 +529,14 @@ class RegistrationTest {
 
         assertEquals("plugin-id", registration.getPluginInfo().getId());
         assertEquals("new-token", registration.getPluginInfo().getToken());
-        verify(cryostat).checkRegistration(any(PluginInfo.class));
+        ArgumentCaptor<PluginInfo> checkedPlugin = ArgumentCaptor.forClass(PluginInfo.class);
+        verify(cryostat).checkRegistration(checkedPlugin.capture());
         verify(cryostat).activateRegistrationRefresh(callback);
-        verify(cryostat).refreshRegistration(eq(callback), any(PluginInfo.class));
+        ArgumentCaptor<PluginInfo> refreshedPlugin = ArgumentCaptor.forClass(PluginInfo.class);
+        verify(cryostat).refreshRegistration(eq(callback), refreshedPlugin.capture());
+        assertEquals("bootstrap-token", checkedPlugin.getValue().getToken());
+        assertEquals("bootstrap-token", refreshedPlugin.getValue().getToken());
+        assertNotSame(checkedPlugin.getValue(), refreshedPlugin.getValue());
         verify(cryostat, times(1)).register(eq(callback), any(), anyCollection());
         verify(cryostat, times(1)).serverHealth();
         verify(webServer, times(1)).generateCredentials(callback);
@@ -624,6 +629,87 @@ class RegistrationTest {
     }
 
     @Test
+    void testRepeatedRetryableRefreshFailuresFallBackToFullRegistration() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        Registration recoveringRegistration =
+                new Registration(
+                        executor,
+                        cryostat,
+                        callbackResolver,
+                        webServer,
+                        appNameResolver,
+                        INSTANCE_ID,
+                        JVM_ID,
+                        APP_NAME,
+                        REALM,
+                        HOSTNAME,
+                        JMX_PORT,
+                        REGISTRATION_RETRY_MS,
+                        REGISTRATION_CHECK_MS,
+                        false,
+                        true,
+                        MAX_BACKOFF_MS,
+                        BACKOFF_MULTIPLIER,
+                        2,
+                        Duration.ZERO,
+                        MIN_COOLDOWN_DURATION,
+                        COOLDOWN_JITTER_FACTOR,
+                        RETRY_BACKOFF_JITTER_FACTOR,
+                        MIN_REGISTRATION_INTERVAL,
+                        random);
+        when(callbackResolver.determineSelfCallback()).thenReturn(callback);
+        when(appNameResolver.extractFromJavaCommand()).thenReturn("test.Main");
+        when(cryostat.serverHealth()).thenReturn(CompletableFuture.completedFuture(serverHealth()));
+        when(cryostat.register(eq(callback), any(), anyCollection()))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "initial-token", List.of())),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("recovered-id", "recovered-token", List.of())));
+        when(cryostat.activateRegistrationRefresh(callback))
+                .thenReturn(
+                        CompletableFuture.completedFuture(
+                                new PluginInfo("plugin-id", "bootstrap-token", List.of())),
+                        CompletableFuture.completedFuture(
+                                new PluginInfo(
+                                        "recovered-id", "recovered-bootstrap-token", List.of())));
+        when(cryostat.refreshRegistration(eq(callback), any(PluginInfo.class)))
+                .thenReturn(
+                        CompletableFuture.failedFuture(new RuntimeException("connection reset")),
+                        CompletableFuture.failedFuture(new RuntimeException("connection reset")));
+        when(random.nextDouble()).thenReturn(0.5);
+        List<Runnable> scheduledTasks = new ArrayList<>();
+        doAnswer(
+                        invocation -> {
+                            scheduledTasks.add(invocation.getArgument(0, Runnable.class));
+                            return scheduledFuture;
+                        })
+                .when(executor)
+                .schedule(any(Runnable.class), anyLong(), any(TimeUnit.class));
+        runSubmittedTasksImmediately();
+
+        recoveringRegistration.start();
+        recoveringRegistration.notify(State.REFRESHING);
+
+        assertEquals("plugin-id", recoveringRegistration.getPluginInfo().getId());
+        assertEquals(1, scheduledTasks.size());
+        scheduledTasks.remove(0).run();
+
+        assertFalse(recoveringRegistration.getPluginInfo().isInitialized());
+        assertEquals(1, scheduledTasks.size());
+        scheduledTasks.remove(0).run();
+
+        assertEquals("recovered-id", recoveringRegistration.getPluginInfo().getId());
+        assertEquals(
+                "recovered-bootstrap-token", recoveringRegistration.getPluginInfo().getToken());
+        verify(callbackResolver, times(2)).determineSelfCallback();
+        verify(cryostat, times(2)).refreshRegistration(eq(callback), any(PluginInfo.class));
+        verify(cryostat, times(2)).register(eq(callback), any(), anyCollection());
+        verify(webServer, times(2)).generateCredentials(callback);
+        verify(webServer, times(2)).commitPendingCredentials();
+    }
+
+    @Test
     void testTerminalRefreshFailureFallsBackToFullRecoveryRegistration() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
         when(callbackResolver.determineSelfCallback()).thenReturn(callback);
@@ -679,13 +765,9 @@ class RegistrationTest {
     }
 
     @Test
-    void testOverlappingRefreshAttemptsAreSerialized() {
+    void testOverlappingRefreshAttemptsAreSerialized() throws Exception {
         URI callback = URI.create("http://agent.example.com:9977");
-        try {
-            stubSuccessfulInitialRegistration(callback, "plugin-id", "old-token");
-        } catch (Exception e) {
-            throw new AssertionError(e);
-        }
+        stubSuccessfulInitialRegistration(callback, "plugin-id", "old-token");
         runSubmittedTasksImmediately();
         registration.start();
 

--- a/src/test/java/io/cryostat/agent/WebServerTest.java
+++ b/src/test/java/io/cryostat/agent/WebServerTest.java
@@ -173,6 +173,74 @@ class WebServerTest {
     }
 
     @Test
+    void testPostPromptsRegistrationRefreshWhileGetOnlyPings() throws Exception {
+        URI callback = URI.create("http://agent.example.com:9977");
+        HttpServer httpServer =
+                HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        WebServer liveWebServer =
+                new WebServer(
+                        new SecureRandom(),
+                        Set::of,
+                        httpServer,
+                        MessageDigest.getInstance("SHA-256"),
+                        "testuser",
+                        16,
+                        () -> registration);
+
+        try {
+            liveWebServer.generateCredentials(callback).get();
+            try (WebServer.CredentialsSnapshot credentials =
+                    liveWebServer.getCredentialsSnapshot()) {
+                liveWebServer.clearPlaintextCredentials();
+                liveWebServer.commitPendingCredentials();
+                liveWebServer.start();
+
+                URI pingUri =
+                        new URI(
+                                "http",
+                                null,
+                                httpServer.getAddress().getHostString(),
+                                httpServer.getAddress().getPort(),
+                                "/",
+                                null,
+                                null);
+                String authorization =
+                        "Basic "
+                                + Base64.getEncoder()
+                                        .encodeToString(
+                                                (credentials.user()
+                                                                + ":"
+                                                                + new String(
+                                                                        credentials.pass(),
+                                                                        StandardCharsets.US_ASCII))
+                                                        .getBytes(StandardCharsets.US_ASCII));
+                HttpClient client = HttpClient.newHttpClient();
+
+                HttpRequest get =
+                        HttpRequest.newBuilder(pingUri)
+                                .header("Authorization", authorization)
+                                .GET()
+                                .build();
+                assertEquals(
+                        204, client.send(get, HttpResponse.BodyHandlers.discarding()).statusCode());
+                verify(registration, never()).notify(any());
+
+                HttpRequest post =
+                        HttpRequest.newBuilder(pingUri)
+                                .header("Authorization", authorization)
+                                .POST(HttpRequest.BodyPublishers.noBody())
+                                .build();
+                assertEquals(
+                        204,
+                        client.send(post, HttpResponse.BodyHandlers.discarding()).statusCode());
+                verify(registration).notify(Registration.RegistrationEvent.State.REFRESHING);
+            }
+        } finally {
+            liveWebServer.stop();
+        }
+    }
+
+    @Test
     void testPendingCredentialsAreCommittedOrDiscardedAtomically() throws Exception {
         SecureRandom random = mock(SecureRandom.class);
         when(random.nextInt(anyInt())).thenReturn(0, 1);

--- a/src/test/java/io/cryostat/agent/WebServerTest.java
+++ b/src/test/java/io/cryostat/agent/WebServerTest.java
@@ -233,7 +233,8 @@ class WebServerTest {
                 assertEquals(
                         204,
                         client.send(post, HttpResponse.BodyHandlers.discarding()).statusCode());
-                verify(registration).notify(Registration.RegistrationEvent.State.REFRESHING);
+                verify(registration, timeout(5000))
+                        .notify(Registration.RegistrationEvent.State.REFRESHING);
             }
         } finally {
             liveWebServer.stop();


### PR DESCRIPTION
see https://github.com/cryostatio/cryostat/issues/1717

Updated Agent registration so expired JWTs are refreshed through the generic discovery endpoint without regenerating or replacing the existing credentials. The Agent now preserves its registration state during refreshes, retries transient failures safely, and falls back to full registration only when recovery is required; tests cover successful refreshes, failure recovery, event handling, and overlapping attempts.